### PR TITLE
DFT+U optimization

### DIFF
--- a/source/src_lcao/dftu.cpp
+++ b/source/src_lcao/dftu.cpp
@@ -112,7 +112,6 @@ void DFTU::init(
 	this->iatlnmipol2iwt.resize(cell.nat);
 	this->iat2it.resize(cell.nat);
 	this->iwt2it.resize(nlocal);
-	this->iwt2iat.resize(nlocal);
 	this->iwt2l.resize(nlocal);
 	this->iwt2n.resize(nlocal);
 	this->iwt2m.resize(nlocal);
@@ -121,7 +120,6 @@ void DFTU::init(
 	for(int i=0; i<nlocal; i++)
 	{
 		this->iwt2it.at(i) = -1;
-		this->iwt2iat.at(i) = -1;
 		this->iwt2l.at(i) = -1;
 		this->iwt2n.at(i) = -1;
 		this->iwt2m.at(i) = -1;
@@ -197,7 +195,6 @@ void DFTU::init(
 								
 				this->iatlnmipol2iwt.at(iat).at(l).at(n).at(m).at(ipol) = iwt;
 				this->iwt2it.at(iwt) = it;
-				this->iwt2iat.at(iwt) = iat;
 				this->iwt2l.at(iwt) = l;
 				this->iwt2n.at(iwt) = n;
 				this->iwt2m.at(iwt) = m;
@@ -1157,27 +1154,27 @@ void DFTU::cal_eff_pot_mat_complex(const int ik, const int istep, complex<double
 	//=============================================================
 	const char transN = 'N', transT = 'T';
 	const int  one_int = 1;
-  const complex<double> alpha_c(1.0,0.0), beta_c(0.0,0.0), half_c(0.5,0.0), one_c(1.0,0.0);
+  const complex<double> zero(0.0,0.0), half(0.5,0.0), one(1.0,0.0);
 
 	vector<complex<double>> VU(ParaO.nloc);
-  this->cal_VU_pot_mat_complex(spin, 1, &VU[0]);
+  this->cal_VU_pot_mat_complex(spin, true, &VU[0]);
 
 	pzgemm_(&transN, &transN,
 		&NLOCAL, &NLOCAL, &NLOCAL,
-		&half_c, 
+		&half, 
 		VECTOR_TO_PTR(VU), &one_int, &one_int, ParaO.desc,
 		LM.Sloc2, &one_int, &one_int, ParaO.desc,
-		&beta_c,
+		&zero,
 		eff_pot, &one_int, &one_int, ParaO.desc);
 
   for(int irc=0; irc<ParaO.nloc; irc++)
     VU[irc] = eff_pot[irc];
   
-  // pztranc(m, n, alpha, a, ia, ja, desca, beta, c, ic, jc, descc)
+  //pztranc(m, n, alpha, a, ia, ja, desca, beta, c, ic, jc, descc)
   pztranc_(&NLOCAL, &NLOCAL, 
-           &one_c, 
+           &one, 
            &VU[0], &one_int, &one_int, ParaO.desc, 
-           &one_c, 
+           &one, 
            eff_pot, &one_int, &one_int, ParaO.desc);
 
 	//code for testing whther the effective potential is Hermitian

--- a/source/src_lcao/dftu_relax.h
+++ b/source/src_lcao/dftu_relax.h
@@ -24,10 +24,10 @@ public:
     ~DFTU_RELAX();
 
     void force_stress();
-    void cal_force_k(const int ik, complex<double>* rho_VU);
-    void cal_stress_k(const int ik, complex<double>* rho_VU);
-    void cal_force_gamma(const int spin, double* rho_VU);
-    void cal_stress_gamma(const int spin, double* rho_VU);
+    void cal_force_k(const int ik, const complex<double>* rho_VU);
+    void cal_stress_k(const int ik, const complex<double>* rho_VU);
+    void cal_force_gamma(const double* rho_VU);
+    void cal_stress_gamma(const double* rho_VU);
 
     void fold_dSR_gamma(const int dim1, const int dim2, double* dSR_gamma);
     void fold_dSm_k(const int ik, const int dim, complex<double>* dSm_k);
@@ -50,7 +50,6 @@ public:
     //transform between iwt index and it, ia, L, N and m index
     vector<vector<vector<vector<vector<int>>>>> iatlnmipol2iwt;   //iatlnm2iwt[iat][l][n][m][ipol]
     vector<int> iwt2it;                               //iwt2it[iwt]
-    vector<int> iwt2iat;                              //iwt2iat[iwt]
     vector<int> iwt2l;                                //iwt2l[iwt]
     vector<int> iwt2n;                                //iwt2n[iwt]
     vector<int> iwt2m;                                //iwt2m[iwt]


### PR DESCRIPTION
1. Fix some errors in force and stress calculation;
2. Accelerate the calculation through deleting some uncessary calling for pblas library for matrixes product.