### PR TITLE
OpenMP optimization for local potential and charge density under k-points line

### DIFF
--- a/source/src_lcao/gint_k_rho.cpp
+++ b/source/src_lcao/gint_k_rho.cpp
@@ -7,7 +7,6 @@
 #include "../src_pw/global.h"
 #include "../module_base/blas_connector.h"
 #include "global_fp.h" // mohan add 2021-01-30
-#include <mkl_service.h>
 
 #ifdef __OPENMP
 #include <omp.h>

--- a/source/src_lcao/gint_k_rho.cpp
+++ b/source/src_lcao/gint_k_rho.cpp
@@ -8,7 +8,7 @@
 #include "../module_base/blas_connector.h"
 #include "global_fp.h" // mohan add 2021-01-30
 
-#ifdef __OPENMP
+#ifdef _OPENMP
 #include <omp.h>
 #endif
 
@@ -408,7 +408,7 @@ void Gint_k::cal_rho_k(void)
     mkl_set_num_threads(1);
 #endif
 
-#ifdef __OPENMP
+#ifdef _OPENMP
     #pragma omp parallel
     {
 #endif
@@ -471,7 +471,7 @@ void Gint_k::cal_rho_k(void)
 	const int ncyz = GlobalC::pw.ncy*GlobalC::pw.nczp;
 	const int nbyz = nby*nbz;	
 
-#ifdef __OPENMP
+#ifdef _OPENMP
     #pragma omp for
 #endif
 	for(int i=0; i<nbx; i++)
@@ -532,7 +532,7 @@ void Gint_k::cal_rho_k(void)
     }	
 
 //	std::cout << " calculate the charge density from density matrix " << std::endl;
-#ifdef __OPENMP
+#ifdef _OPENMP
     } //end omp
 #endif
 

--- a/source/src_lcao/gint_k_vl.cpp
+++ b/source/src_lcao/gint_k_vl.cpp
@@ -8,7 +8,7 @@
 #include "../module_base/blas_connector.h"
 //#include <mkl_cblas.h>
 
-#ifdef __OPENMP
+#ifdef _OPENMP
 #include <omp.h>
 #endif
 
@@ -364,7 +364,7 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
     mkl_set_num_threads(1);
 #endif
 
-#ifdef __OPENMP
+#ifdef _OPENMP
     #pragma omp parallel
     {
         double* pvpR_reduced_thread;
@@ -435,7 +435,7 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
 	double* vldr3 = new double[bxyz];
 	ModuleBase::GlobalFunc::ZEROS(vldr3, bxyz);
 
-#ifdef __OPENMP
+#ifdef _OPENMP
         #pragma omp for
 #endif
 	for(int i=0; i<nbx; i++)
@@ -480,7 +480,7 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
 
 				if(this->reduced)
 				{
-#ifdef __OPENMP
+#ifdef _OPENMP
 					cal_pvpR_reduced(size, LD_pool, grid_index, 
 									ibx, jby, kbz, 
 									block_size, at, block_index, block_iw, 
@@ -503,7 +503,7 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
 		}// int j
 	} // int i
 
-#ifdef __OPENMP
+#ifdef _OPENMP
         #pragma omp critical(cal_vl_k)
         for(int innrg=0; innrg<GlobalC::LNNR.nnrg; innrg++)
         {
@@ -530,7 +530,7 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
 		delete[] block_size;
 		delete[] block_index;
 	}
-#ifdef __OPENMP
+#ifdef _OPENMP
     } // end omp
 #endif
 

--- a/source/src_lcao/gint_k_vl.cpp
+++ b/source/src_lcao/gint_k_vl.cpp
@@ -8,6 +8,14 @@
 #include "../module_base/blas_connector.h"
 //#include <mkl_cblas.h>
 
+#ifdef __OPENMP
+#include <omp.h>
+#endif
+
+#ifdef __MKL
+#include <mkl_service.h>
+#endif
+
 inline int find_offset(const int size, const int grid_index, 
 				const int ibx, const int jby, const int kbz, 
 				const int bx, const int by, const int bz, 
@@ -351,6 +359,18 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
 
 	ModuleBase::timer::tick("Gint_k","vlocal");
 
+#ifdef __MKL
+    const int mkl_threads = mkl_get_max_threads();
+    mkl_set_num_threads(1);
+#endif
+
+#ifdef __OPENMP
+    #pragma omp parallel
+    {
+        double* pvpR_reduced_thread;
+        pvpR_reduced_thread = new double[GlobalC::LNNR.nnrg];
+        ModuleBase::GlobalFunc::ZEROS(pvpR_reduced_thread, GlobalC::LNNR.nnrg);
+#endif
 	// it's a uniform grid to save orbital values, so the delta_r is a constant.
 	double delta_r = GlobalC::ORB.dr_uniform;
 	// possible max atom number in real space grid. 
@@ -415,6 +435,9 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
 	double* vldr3 = new double[bxyz];
 	ModuleBase::GlobalFunc::ZEROS(vldr3, bxyz);
 
+#ifdef __OPENMP
+        #pragma omp for
+#endif
 	for(int i=0; i<nbx; i++)
 	{
 		const int ibx=i*GlobalC::pw.bx;
@@ -457,11 +480,19 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
 
 				if(this->reduced)
 				{
+#ifdef __OPENMP
+					cal_pvpR_reduced(size, LD_pool, grid_index, 
+									ibx, jby, kbz, 
+									block_size, at, block_index, block_iw, 
+									vldr3, psir_ylm, psir_vlbr3, 
+									distance, cal_flag, pvpR_reduced_thread);
+#else
 					cal_pvpR_reduced(size, LD_pool, grid_index, 
 									ibx, jby, kbz, 
 									block_size, at, block_index, block_iw, 
 									vldr3, psir_ylm, psir_vlbr3, 
 									distance, cal_flag, this->pvpR_reduced[spin]);
+#endif
 				}
 				else
 				{
@@ -471,6 +502,15 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
 			}// int k
 		}// int j
 	} // int i
+
+#ifdef __OPENMP
+        #pragma omp critical(cal_vl_k)
+        for(int innrg=0; innrg<GlobalC::LNNR.nnrg; innrg++)
+        {
+            pvpR_reduced[spin][innrg] += pvpR_reduced_thread[innrg];
+        }
+        delete[] pvpR_reduced_thread;
+#endif
 
 	delete[] vldr3;
 	if(max_size!=0)
@@ -489,7 +529,14 @@ void Gint_k::cal_vlocal_k(const double *vrs1, const Grid_Technique &GridT, const
 		delete[] block_iw;
 		delete[] block_size;
 		delete[] block_index;
-	}	
+	}
+#ifdef __OPENMP
+    } // end omp
+#endif
+
+#ifdef __MKL
+    mkl_set_num_threads(mkl_threads);
+#endif
 
 	ModuleBase::timer::tick("Gint_k","vlocal");
 	return;


### PR DESCRIPTION
Test Results: Si64-diamond
mpi-1, omp-*
  Time (sec)    omp-1    omp-2    omp-4    omp-8    omp-16
  vlocal           26           13           7.5          4.0          2.6
  rho               13           6.9          4.1          2.6          1.6

mpi-4, omp-*
  Time (sec)    omp-1    omp-2    omp-4    omp-8
  vlocal           7.0           3.4          1.8          0.96 
  rho               3.4           1.7          0.92        0.50