### PR TITLE
To output final structure STRU_ION_D when atoms are fixed and out_stru is set to be 0 in cell-relax calculation

### DIFF
--- a/source/module_relaxation/lattice_change_basic.cpp
+++ b/source/module_relaxation/lattice_change_basic.cpp
@@ -150,21 +150,22 @@ void Lattice_Change_Basic::change_lattice(double *move, double *lat)
        "<<std::setprecision(12)<<GlobalC::ucell.latvec.e31<<"   "<<GlobalC::ucell.latvec.e32<<"
        "<<GlobalC::ucell.latvec.e33<<std::endl;
     */
+        //--------------------------------------------
+        // Print out the structure file.
+        //--------------------------------------------
+    std::stringstream ss;
+    ss << GlobalV::global_out_dir << "STRU_ION";
     if (out_stru == 1)
     {
-        //--------------------------------------------
-	    // Print out the structure file.
-	    //--------------------------------------------
-	    std::stringstream ss;
-	    ss << GlobalV::global_out_dir << "STRU_ION" << istep;
-	    ss << "_D";
+        ss << istep;
+        GlobalC::ucell.print_cell_cif("STRU_NOW.cif");
+    }
+    ss << "_D";    
 #ifdef __LCAO
 	    GlobalC::ucell.print_stru_file(GlobalC::ORB,ss.str(), 2, 0);
 #else
 	    GlobalC::ucell.print_stru_file(ss.str(), 2, 0);
 #endif
-        GlobalC::ucell.print_cell_cif("STRU_NOW.cif");
-    }
 
     return;
 }


### PR DESCRIPTION
Sorry to open pull request again as deepmodeling/abacus-develop is already merged into abacusmodeling/abacus-develop right now. 

https://github.com/abacusmodeling/abacus-develop/commit/14eb39d2fef7a8ea559db0cf90b89253c9630c85 (Fix: no output of STRU_ION file when atoms fixed (#1304) ) still have problem of not output final structure while doing atom-fixed cell-relax calculation (though can output structures during optimization process by setting out_stru=1) but it is not like all-atom-relaxed relax or cell-relax calculation do.