### PR TITLE
Fix: several bugs exceeded the upper limit of int when calculating large systems

### DIFF
--- a/source/module_hamilt_lcao/hamilt_lcaodft/DM_gamma.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/DM_gamma.cpp
@@ -42,12 +42,13 @@ void Local_Orbital_Charge::allocate_gamma(
     // mohan update 2010-09-06
     if(lgd_now > 0)
     {
+		const std::size_t size_lgd_squre = static_cast<std::size_t>(lgd_now) * lgd_now;
 		this->DM = new double**[GlobalV::NSPIN];
 		this->DM_pool = new double *[GlobalV::NSPIN];
 		for(int is=0; is<GlobalV::NSPIN; is++)
 		{
-			this->DM_pool[is]=new double [lgd_now*lgd_now];
-			ModuleBase::GlobalFunc::ZEROS(DM_pool[is], lgd_now*lgd_now);
+			this->DM_pool[is]=new double [size_lgd_squre];
+			ModuleBase::GlobalFunc::ZEROS(DM_pool[is], size_lgd_squre);
 			this->DM[is] = new double*[lgd_now];
 
 			for (int i=0; i<lgd_now; i++)
@@ -57,7 +58,7 @@ void Local_Orbital_Charge::allocate_gamma(
 		}
 		this->init_DM = true;
         this->lgd_last = lgd_now;
-        ModuleBase::Memory::record("LOC::DM", sizeof(double) * GlobalV::NSPIN*lgd_now*lgd_now);
+        ModuleBase::Memory::record("LOC::DM", sizeof(double) * GlobalV::NSPIN*size_lgd_squre);
         //xiaohui add 'GlobalV::OUT_LEVEL', 2015-09-16
         if(GlobalV::OUT_LEVEL != "m") GlobalV::ofs_running << " allocate DM , the dimension is " << lgd_now << std::endl;
     }

--- a/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/hamilt_lcao.cpp
@@ -69,8 +69,9 @@ HamiltLCAO<TK, TR>::HamiltLCAO(
     this->hR = new HContainer<TR>(LM_in->ParaV);
     this->sR = new HContainer<TR>(LM_in->ParaV);
 
-    this->getSk(LM_in).resize(LM_in->ParaV->get_row_size() * LM_in->ParaV->get_col_size());
-    this->getHk(LM_in).resize(LM_in->ParaV->get_row_size() * LM_in->ParaV->get_col_size());
+    const std::size_t row_col_size = static_cast<std::size_t>(LM_in->ParaV->get_row_size()) * LM_in->ParaV->get_col_size();
+    this->getSk(LM_in).resize(row_col_size);
+    this->getHk(LM_in).resize(row_col_size);
 
     // Effective potential term (\sum_r <psi(r)|Veff(r)|psi(r)>) is registered without template
     std::vector<std::string> pot_register_in;

--- a/source/module_hsolver/genelpa/elpa_new.cpp
+++ b/source/module_hsolver/genelpa/elpa_new.cpp
@@ -432,7 +432,7 @@ int ELPA_Solver::read_complex_kernel()
 
 int ELPA_Solver::allocate_work()
 {
-    unsigned long nloc = narows * nacols; // local size
+    unsigned long nloc = static_cast<unsigned long>(narows) * nacols; // local size
     unsigned long maxloc; // maximum local size
     MPI_Allreduce(&nloc, &maxloc, 1, MPI_UNSIGNED_LONG, MPI_MAX, comm);
     maxloc = nloc;

--- a/source/module_hsolver/genelpa/elpa_new_real.cpp
+++ b/source/module_hsolver/genelpa/elpa_new_real.cpp
@@ -248,7 +248,7 @@ int ELPA_Solver::decomposeRightMatrix(double* B, double* EigenValue, double* Eig
             {
                 int iGlobal = globalIndex(i, nblk, nprows, myprow);
                 if (iGlobal > jGlobal)
-                    B[i + j * narows] = 0;
+                    B[i + j * static_cast<std::size_t>(narows)] = 0;
             }
         }
         if (loglevel > 1)
@@ -295,8 +295,9 @@ int ELPA_Solver::decomposeRightMatrix(double* B, double* EigenValue, double* Eig
             int eidx = globalIndex(i, nblk, npcols, mypcol);
             // double ev_sqrt=1.0/sqrt(ev[eidx]);
             double ev_sqrt = EigenValue[eidx] > DBL_MIN ? 1.0 / sqrt(EigenValue[eidx]) : 0;
+            const std::size_t index_i = i * static_cast<std::size_t>(lda);
             for (int j = 0; j < narows; ++j)
-                dwork[i * lda + j] = EigenVector[i * lda + j] * ev_sqrt;
+                dwork[index_i + j] = EigenVector[index_i + j] * ev_sqrt;
         }
 
         // calculate work*q=q*ev^{-1/2}*q^T, put to b, which is B^{-1/2}
@@ -356,7 +357,7 @@ int ELPA_Solver::composeEigenVector(int DecomposedState, double* B, double* Eige
 void ELPA_Solver::verify(double* A, double* EigenValue, double* EigenVector, double& maxError, double& meanError)
 {
     double* V = EigenVector;
-    const int naloc = narows * nacols;
+    const std::size_t naloc = static_cast<std::size_t>(narows) * nacols;
     double* D = new double[naloc];
     double* R = dwork.data();
 
@@ -374,7 +375,7 @@ void ELPA_Solver::verify(double* A, double* EigenValue, double* EigenVector, dou
             localCol = localIndex(i, nblk, npcols, localProcCol);
             if (mypcol == localProcCol)
             {
-                int idx = localRow + localCol * narows;
+                const std::size_t idx = localRow + localCol * static_cast<std::size_t>(narows);
                 D[idx] = EigenValue[i];
             }
         }
@@ -413,7 +414,7 @@ void ELPA_Solver::verify(double* A,
                          double& meanError)
 {
     double* V = EigenVector;
-    const int naloc = narows * nacols;
+    const std::size_t naloc = static_cast<std::size_t>(narows) * nacols;
     double* D = new double[naloc];
     double* R = new double[naloc];
 
@@ -431,7 +432,7 @@ void ELPA_Solver::verify(double* A,
             localCol = localIndex(i, nblk, npcols, localProcCol);
             if (mypcol == localProcCol)
             {
-                int idx = localRow + localCol * narows;
+                const std::size_t idx = localRow + localCol * static_cast<std::size_t>(narows);
                 D[idx] = EigenValue[i];
             }
         }

--- a/source/module_psi/psi.cpp
+++ b/source/module_psi/psi.cpp
@@ -178,7 +178,7 @@ void Psi<T, Device>::resize(const int nks_in, const int nbands_in, const int nba
 {
     assert(nks_in > 0 && nbands_in >= 0 && nbasis_in > 0);
     // This function will delete the psi array first(if psi exist), then malloc a new memory for it.
-    resize_memory_op()(this->ctx, this->psi, nks_in * nbands_in * nbasis_in, "no_record");
+    resize_memory_op()(this->ctx, this->psi, nks_in * static_cast<std::size_t>(nbands_in) * nbasis_in, "no_record");
     this->nk = nks_in;
     this->nbands = nbands_in;
     this->nbasis = nbasis_in;
@@ -234,13 +234,13 @@ template <typename T, typename Device> const int& Psi<T, Device>::get_nbasis() c
     return this->nbasis;
 }
 
-template <typename T, typename Device> size_t Psi<T, Device>::size() const
+template <typename T, typename Device> std::size_t Psi<T, Device>::size() const
 {
     if (this->psi == nullptr)
     {
         return 0;
     }
-    return this->nk * this->nbands * this->nbasis;
+    return this->nk * static_cast<std::size_t>(this->nbands) * this->nbasis;
 }
 
 template <typename T, typename Device> void Psi<T, Device>::fix_k(const int ik) const


### PR DESCRIPTION
1. Local_Orbital_Charge::allocate_gamma()
2. HamiltLCAO::HamiltLCAO()
3. ELPA_Solver::allocate_work()
4. ELPA_Solver::decomposeRightMatrix()
5. ELPA_Solver::verify()
6. Psi::resize()
7. Psi::size()

As shown in issue #3219, large systems with few processes exceed the upper limit of int.
There are still bugs unfixed in codes, such as class Parallel_Orbitals.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
