### PR TITLE
Add ENABLE_RAPIDJSON option to control the output of abacus.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ if(ENABLE_RAPIDJSON)
       GIT_PROGRESS TRUE
     )
     FetchContent_MakeAvailable(rapidjson)
+    set(RapidJSON_INCLUDE_PATH "${CMAKE_CURRENT_BINARY_DIR}/_deps/rapidjson-src/include/")
   endif()
   add_compile_definitions(__RAPIDJSON)
   include_directories(${RapidJSON_INCLUDE_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ option(ENABLE_RAPIDJSON "Enable rapid-json usage." OFF)
 
 # enable json support
 if(ENABLE_RAPIDJSON)
-  find_package(RapidJSON REQUIRED)
+  find_package(RapidJSON)
   if(NOT RapidJSON_FOUND)
     message(WARNING "Rapidjson is not found, trying downloading from github, or you can install Rapidjson first and reinstall abacus.")
     include(FetchContent)
@@ -51,7 +51,7 @@ if(ENABLE_RAPIDJSON)
       GIT_SHALLOW TRUE
       GIT_PROGRESS TRUE
     )
-    FetchContent_MakeAvailable(googletest)
+    FetchContent_MakeAvailable(rapidjson)
   endif()
   add_compile_definitions(__RAPIDJSON)
   include_directories(${RapidJSON_INCLUDE_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,30 @@ option(DEBUG_INFO "Print message for developers to debug." OFF)
 option(ENABLE_NATIVE_OPTIMIZATION "Enable compilation optimization for the native machine's CPU type" OFF)
 option(COMMIT_INFO "Print commit information in log" ON)
 option(ENABLE_FFT_TWO_CENTER "Enable FFT-based two-center integral method." ON)
+option(ENABLE_RAPIDJSON "Enable rapid-json usage." OFF)
+
+
+
+# enable json support
+if(ENABLE_RAPIDJSON)
+  find_package(RapidJSON REQUIRED)
+  if(NOT RapidJSON_FOUND)
+    message(WARNING "Rapidjson is not found, trying downloading from github, or you can install Rapidjson first and reinstall abacus.")
+    include(FetchContent)
+    FetchContent_Declare(
+      rapidjson
+      GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
+      GIT_TAG "origin/master"
+      GIT_SHALLOW TRUE
+      GIT_PROGRESS TRUE
+    )
+    FetchContent_MakeAvailable(googletest)
+  endif()
+  add_compile_definitions(__RAPIDJSON)
+  include_directories(${RapidJSON_INCLUDE_PATH})
+endif()
+
+
 if (USE_CUDA)
   set(USE_CUSOLVER_LCAO ON)
 else()

--- a/source/module_base/para_json.cpp
+++ b/source/module_base/para_json.cpp
@@ -1,7 +1,7 @@
-
 #include "para_json.h"
 #include "module_base/global_variable.h"
 
+#ifdef __RAPIDJSON
 
 namespace Para_Json
 {
@@ -972,3 +972,6 @@ namespace Para_Json
 
 
 }
+
+
+#endif

--- a/source/module_base/para_json.h
+++ b/source/module_base/para_json.h
@@ -5,6 +5,8 @@
 #include <sstream>
 #include <vector>
 
+#ifdef __RAPIDJSON
+
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>
 #include <rapidjson/stringbuffer.h>
@@ -555,3 +557,4 @@ namespace Para_Json
     }
 }
 
+#endif

--- a/source/module_base/parallel_global.cpp
+++ b/source/module_base/parallel_global.cpp
@@ -17,7 +17,9 @@
 #include "module_base/global_function.h"
 #include "module_base/parallel_common.h"
 #include "module_base/parallel_reduce.h"
+#ifdef __RAPIDJSON 
 #include "module_base/para_json.h"
+#endif
 #include "version.h"
 
 #if defined __MPI
@@ -96,11 +98,11 @@ void Parallel_Global::split_diag_world(const int &diag_np)
 	GlobalV::DRANK=0;
 	GlobalV::DSIZE=1;
 #endif
-
+#ifdef __RAPIDJSON 
     Para_Json::set_json_value(Para_Json::drank,&GlobalV::DRANK); 
     Para_Json::set_json_value(Para_Json::dsize,&GlobalV::DSIZE); 
     Para_Json::set_json_value(Para_Json::dcolor,&GlobalV::DCOLOR); 
-
+#endif
 	return;
 }
 

--- a/source/module_io/input.cpp
+++ b/source/module_io/input.cpp
@@ -22,8 +22,11 @@
 #include "module_base/global_variable.h"
 #include "module_base/parallel_common.h"
 #include "module_base/timer.h"
-#include "module_base/para_json.h"
 
+
+#ifdef __RAPIDJSON 
+#include "module_base/para_json.h"
+#endif
 #include "version.h"
 Input INPUT;
 
@@ -138,15 +141,23 @@ void Input::Init(const std::string &fn)
     std::string commit_json = commit;
     std::string device_json = device;
     printf("version = %s\n",device_json.c_str());
-    Para_Json::set_json_value(Para_Json::version,&version_json); 
-    Para_Json::set_json_value(Para_Json::commit,&commit_json); 
-    Para_Json::set_json_value(Para_Json::device_g,&device_json);
-    Para_Json::set_json_value(Para_Json::begin_time,&begin_time);  
-    
-    Para_Json::set_json_value(Para_Json::global_out_dir,&GlobalV::global_out_dir); 
-    Para_Json::set_json_value(Para_Json::global_in_card,&GlobalV::global_in_card);
-    Para_Json::set_json_value(Para_Json::pseudo_dir_path,&GlobalV::global_pseudo_dir);  
-    Para_Json::set_json_value(Para_Json::orbital_dir_path,&GlobalV::global_orbital_dir);  
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::version,&version_json);  
+
+		 Para_Json::set_json_value(Para_Json::commit,&commit_json);  
+
+		 Para_Json::set_json_value(Para_Json::device_g,&device_json); 
+
+		 Para_Json::set_json_value(Para_Json::begin_time,&begin_time);   
+
+		 Para_Json::set_json_value(Para_Json::global_out_dir,&GlobalV::global_out_dir);  
+
+		 Para_Json::set_json_value(Para_Json::global_in_card,&GlobalV::global_in_card); 
+
+		 Para_Json::set_json_value(Para_Json::pseudo_dir_path,&GlobalV::global_pseudo_dir);   
+
+		 Para_Json::set_json_value(Para_Json::orbital_dir_path,&GlobalV::global_orbital_dir);   
+#endif
     return;
 }
 
@@ -704,18 +715,24 @@ bool Input::Read(const std::string &fn)
         if (strcmp("suffix", word) == 0) // out dir
         {
             read_value(ifs, suffix);
-            Para_Json::set_json_value(Para_Json::input_suffix,&suffix);
-            //Para_Json::set_json_value(Para_Json::suffix,&suffix); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::input_suffix,&suffix); 
+#endif
+            
         }
         else if (strcmp("stru_file", word) == 0) // xiaohui modify 2015-02-01
         {
             read_value(ifs, stru_file); // xiaohui modify 2015-02-01
-            Para_Json::set_json_value(Para_Json::stru_file,&stru_file); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::stru_file,&stru_file);  
+#endif
         }
         else if (strcmp("pseudo_dir", word) == 0)
         {
             read_value(ifs, pseudo_dir);
-            Para_Json::set_json_value(Para_Json::pseudo_dir,&pseudo_dir); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::pseudo_dir,&pseudo_dir);  
+#endif
         }
         // else if (strcmp("pseudo_type", word) == 0) // mohan add 2013-05-20 (xiaohui add 2013-06-23)
         // {
@@ -724,53 +741,73 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("orbital_dir", word) == 0) // liuyu add 2021-08-14
         {
             read_value(ifs, orbital_dir);
-            Para_Json::set_json_value(Para_Json::orbital_dir,&orbital_dir); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::orbital_dir,&orbital_dir);  
+#endif
         }
         else if (strcmp("kpoint_file", word) == 0) // xiaohui modify 2015-02-01
         {
             read_value(ifs, kpoint_file); // xiaohui modify 2015-02-01
-            Para_Json::set_json_value(Para_Json::kpoint_file,&kpoint_file); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::kpoint_file,&kpoint_file);  
+#endif
         }
         else if (strcmp("wannier_card", word) == 0) // mohan add 2009-12-25
         {
             read_value(ifs, wannier_card);
-            Para_Json::set_json_value(Para_Json::kpoint_file,&kpoint_file); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::kpoint_file,&kpoint_file);  
+#endif
         }
         else if (strcmp("latname", word) == 0) // which material
         {
             read_value(ifs, latname);
-            Para_Json::set_json_value(Para_Json::latname,&latname); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::latname,&latname);  
+#endif
         }
         else if (strcmp("pseudo_rcut", word) == 0) //
         {
             read_value(ifs, pseudo_rcut);
 
-            Para_Json::set_json_value(Para_Json::pseudo_rcut,&pseudo_rcut);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::pseudo_rcut,&pseudo_rcut); 
+#endif
         }
         else if (strcmp("pseudo_mesh", word) == 0) //
         {
             read_bool(ifs, pseudo_mesh);
-            Para_Json::set_json_value(Para_Json::pseudo_mesh,&pseudo_mesh);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::pseudo_mesh,&pseudo_mesh); 
+#endif
         }
         else if (strcmp("calculation", word) == 0) // which type calculation
         {
             read_value(ifs, calculation);
-            Para_Json::set_json_value(Para_Json::calculation,&calculation); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::calculation,&calculation);  
+#endif
         }
         else if (strcmp("esolver_type", word) == 0)
         {
             read_value(ifs, esolver_type);
-            Para_Json::set_json_value(Para_Json::esolver_type,&esolver_type); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::esolver_type,&esolver_type);  
+#endif
         }
         else if (strcmp("ntype", word) == 0) // number of atom types
         {
             read_value(ifs, ntype);
-            Para_Json::set_json_value(Para_Json::ntype,&ntype); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::ntype,&ntype);  
+#endif
         }
         else if (strcmp("nbands", word) == 0) // number of atom bands
         {
             read_value(ifs, nbands);
-            Para_Json::set_json_value(Para_Json::nbands,&nbands); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nbands,&nbands);  
+#endif
         }
         else if (strcmp("nbands_sto", word) == 0) // number of stochastic bands
         {
@@ -782,24 +819,32 @@ bool Input::Read(const std::string &fn)
             {
                 nbands_sto = std::stoi(nbndsto_str);
             }
-            Para_Json::set_json_value(Para_Json::nbands_sto,&nbands_sto); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nbands_sto,&nbands_sto);  
+#endif
         }
         else if (strcmp("kspacing", word) == 0)
         {
             read_kspacing(ifs);
             for(int i=0;i<3;i++){
+#ifdef __RAPIDJSON 
                 Para_Json::kspacing.PushBack(kspacing[i],Para_Json::doc.GetAllocator());
+#endif
             }
         }
         else if (strcmp("min_dist_coef", word) == 0)
         {
             read_value(ifs, min_dist_coef);
-            Para_Json::set_json_value(Para_Json::min_dist_coef,&min_dist_coef); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::min_dist_coef,&min_dist_coef);  
+#endif
         }
         else if (strcmp("nbands_istate", word) == 0) // number of atom bands
         {
             read_value(ifs, nbands_istate);
-            Para_Json::set_json_value(Para_Json::nbands_istate,&nbands_istate); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nbands_istate,&nbands_istate);  
+#endif
             // Originally disabled in line 2401.
             // if (nbands_istate < 0)
             // 	ModuleBase::WARNING_QUIT("Input", "NBANDS_ISTATE must > 0");
@@ -807,12 +852,16 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("nche_sto", word) == 0) // Chebyshev expansion order
         {
             read_value(ifs, nche_sto);
-            Para_Json::set_json_value(Para_Json::nche_sto,&nche_sto); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nche_sto,&nche_sto);  
+#endif
         }
         else if (strcmp("seed_sto", word) == 0)
         {
             read_value(ifs, seed_sto);
-            Para_Json::set_json_value(Para_Json::seed_sto,&seed_sto); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::seed_sto,&seed_sto);  
+#endif
         }
         else if (strcmp("initsto_ecut", word) == 0)
         {
@@ -821,62 +870,86 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("pw_seed", word) == 0)
         {
             read_value(ifs, pw_seed);
-            Para_Json::set_json_value(Para_Json::pw_seed,&pw_seed); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::pw_seed,&pw_seed);  
+#endif
         }
         else if (strcmp("emax_sto", word) == 0)
         {
             read_value(ifs, emax_sto);
-            Para_Json::set_json_value(Para_Json::emax_sto,&emax_sto); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::emax_sto,&emax_sto);  
+#endif
         }
         else if (strcmp("emin_sto", word) == 0)
         {
             read_value(ifs, emin_sto);
-            Para_Json::set_json_value(Para_Json::emin_sto,&emin_sto); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::emin_sto,&emin_sto);  
+#endif
         }
         else if (strcmp("initsto_freq", word) == 0)
         {
             read_value(ifs, initsto_freq);
-            Para_Json::set_json_value(Para_Json::initsto_freq,&initsto_freq); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::initsto_freq,&initsto_freq);  
+#endif
         }
         else if (strcmp("method_sto", word) == 0)
         {
             read_value(ifs, method_sto);
-            Para_Json::set_json_value(Para_Json::method_sto,&method_sto); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::method_sto,&method_sto);  
+#endif
         }
         else if (strcmp("npart_sto", word) == 0)
         {
             read_value(ifs, npart_sto);
-            Para_Json::set_json_value(Para_Json::npart_sto,&npart_sto); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::npart_sto,&npart_sto);  
+#endif
         }
         else if (strcmp("cal_cond", word) == 0)
         {
             read_bool(ifs, cal_cond);
-            Para_Json::set_json_value(Para_Json::cal_cond,&cal_cond);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cal_cond,&cal_cond); 
+#endif
         }
         else if (strcmp("cond_che_thr", word) == 0)
         {
             read_value(ifs, cond_che_thr);
-            Para_Json::set_json_value(Para_Json::cond_nche,&cond_che_thr); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cond_nche,&cond_che_thr);  
+#endif
         }
         else if (strcmp("cond_dw", word) == 0)
         {
             read_value(ifs, cond_dw);
-            Para_Json::set_json_value(Para_Json::cond_dw,&cond_dw); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cond_dw,&cond_dw);  
+#endif
         }
         else if (strcmp("cond_wcut", word) == 0)
         {
             read_value(ifs, cond_wcut);
-            Para_Json::set_json_value(Para_Json::cond_wcut,&cond_wcut); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cond_wcut,&cond_wcut);  
+#endif
         }
         else if (strcmp("cond_dt", word) == 0)
         {
             read_value(ifs, cond_dt);
-            Para_Json::set_json_value(Para_Json::cond_dt,&cond_dt); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cond_dt,&cond_dt);  
+#endif
         }
         else if (strcmp("cond_dtbatch", word) == 0)
         {
             read_value(ifs, cond_dtbatch);
-            Para_Json::set_json_value(Para_Json::cond_dtbatch,&cond_dtbatch); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cond_dtbatch,&cond_dtbatch);  
+#endif
         }
         else if (strcmp("cond_smear", word) == 0)
         {
@@ -885,47 +958,65 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("cond_fwhm", word) == 0)
         {
             read_value(ifs, cond_fwhm);
-            Para_Json::set_json_value(Para_Json::cond_fwhm,&cond_fwhm); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cond_fwhm,&cond_fwhm);  
+#endif
         }
         else if (strcmp("cond_nonlocal", word) == 0)
         {
             read_bool(ifs, cond_nonlocal);
-            Para_Json::set_json_value(Para_Json::cond_nonlocal,&cond_nonlocal);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cond_nonlocal,&cond_nonlocal); 
+#endif
         }
         else if (strcmp("bndpar", word) == 0)
         {
             read_value(ifs, bndpar);
-            Para_Json::set_json_value(Para_Json::bndpar,&bndpar); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bndpar,&bndpar);  
+#endif
         }
         else if (strcmp("kpar", word) == 0) // number of pools
         {
             read_value(ifs, kpar);
-            Para_Json::set_json_value(Para_Json::kpar,&kpar); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::kpar,&kpar);  
+#endif
         }
         else if (strcmp("berry_phase", word) == 0) // berry phase calculation
         {
             read_bool(ifs, berry_phase);
-            Para_Json::set_json_value(Para_Json::berry_phase,&berry_phase);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::berry_phase,&berry_phase); 
+#endif
         }
         else if (strcmp("gdir", word) == 0) // berry phase calculation
         {
             read_value(ifs, gdir);
-            Para_Json::set_json_value(Para_Json::gdir,&gdir); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::gdir,&gdir);  
+#endif
         }
         else if (strcmp("towannier90", word) == 0) // add by jingan for wannier90
         {
             read_bool(ifs, towannier90);
-            Para_Json::set_json_value(Para_Json::towannier90,&towannier90);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::towannier90,&towannier90); 
+#endif
         }
         else if (strcmp("nnkpfile", word) == 0) // add by jingan for wannier90
         {
             read_value(ifs, nnkpfile);
-            Para_Json::set_json_value(Para_Json::nnkpfile,&nnkpfile); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nnkpfile,&nnkpfile);  
+#endif
         }
         else if (strcmp("wannier_spin", word) == 0) // add by jingan for wannier90
         {
             read_value(ifs, wannier_spin);
-            Para_Json::set_json_value(Para_Json::wannier_spin,&wannier_spin); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::wannier_spin,&wannier_spin);  
+#endif
         }
             else if (strcmp("out_wannier_mmn", word) == 0) // add by renxi for wannier90
         {
@@ -953,32 +1044,44 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("dft_functional", word) == 0)
         {
             read_value(ifs, dft_functional);
-            Para_Json::set_json_value(Para_Json::dft_functional,&dft_functional); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dft_functional,&dft_functional);  
+#endif
         }
         else if (strcmp("xc_temperature", word) == 0)
         {
             read_value(ifs, xc_temperature);
-            Para_Json::set_json_value(Para_Json::xc_temperature,&xc_temperature); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::xc_temperature,&xc_temperature);  
+#endif
         }
         else if (strcmp("nspin", word) == 0)
         {
             read_value(ifs, nspin);
-            Para_Json::set_json_value(Para_Json::nspin,&nspin); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nspin,&nspin);  
+#endif
         }
         else if (strcmp("nelec", word) == 0)
         {
             read_value(ifs, nelec);
-            Para_Json::set_json_value(Para_Json::nelec,&nelec); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nelec,&nelec);  
+#endif
         }
         else if (strcmp("nupdown", word) == 0)
         {
             read_value(ifs, nupdown);
-            Para_Json::set_json_value(Para_Json::nupdown,&nupdown); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nupdown,&nupdown);  
+#endif
         }
         else if (strcmp("lmaxmax", word) == 0)
         {
             read_value(ifs, lmaxmax);
-            Para_Json::set_json_value(Para_Json::lmaxmax,&lmaxmax); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::lmaxmax,&lmaxmax);  
+#endif
         }
         //----------------------------------------------------------
         // new function
@@ -986,42 +1089,58 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("basis_type", word) == 0)
         {
             read_value(ifs, basis_type);
-            Para_Json::set_json_value(Para_Json::basis_type,&basis_type); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::basis_type,&basis_type);  
+#endif
         } // xiaohui add 2013-09-01
         else if (strcmp("ks_solver", word) == 0)
         {
             read_value(ifs, ks_solver);
-            Para_Json::set_json_value(Para_Json::ks_solver,&ks_solver); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::ks_solver,&ks_solver);  
+#endif
         } // xiaohui add 2013-09-01
         else if (strcmp("search_radius", word) == 0)
         {
             read_value(ifs, search_radius);
-            Para_Json::set_json_value(Para_Json::search_radius,&search_radius); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::search_radius,&search_radius);  
+#endif
         }
         else if (strcmp("search_pbc", word) == 0)
         {
             read_bool(ifs, search_pbc);
-            Para_Json::set_json_value(Para_Json::search_pbc,&search_pbc);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::search_pbc,&search_pbc); 
+#endif
         }
         else if (strcmp("symmetry", word) == 0)
         {
             read_value(ifs, symmetry);
-            Para_Json::set_json_value(Para_Json::symmetry,&symmetry); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::symmetry,&symmetry);  
+#endif
         }
         else if (strcmp("init_vel", word) == 0)
         {
             read_bool(ifs, init_vel);
-            Para_Json::set_json_value(Para_Json::init_vel,&init_vel);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::init_vel,&init_vel); 
+#endif
         }
         else if (strcmp("ref_cell_factor", word) == 0)
         {
             read_value(ifs, ref_cell_factor);
-            Para_Json::set_json_value(Para_Json::ref_cell_factor,&ref_cell_factor); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::ref_cell_factor,&ref_cell_factor);  
+#endif
         }
         else if (strcmp("symmetry_prec", word) == 0) // LiuXh add 2021-08-12, accuracy for symmetry
         {
             read_value(ifs, symmetry_prec);
-            Para_Json::set_json_value(Para_Json::symmetry_precfield,&symmetry_prec); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::symmetry_precfield,&symmetry_prec);  
+#endif
         }
         else if (strcmp("symmetry_autoclose", word) == 0)
         {
@@ -1030,114 +1149,158 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("cal_force", word) == 0)
         {
             read_bool(ifs, cal_force);
-            Para_Json::set_json_value(Para_Json::cal_force,&cal_force); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cal_force,&cal_force);  
+#endif
         }
         else if (strcmp("force_thr", word) == 0)
         {
             read_value(ifs, force_thr);
-            Para_Json::set_json_value(Para_Json::force_thr,&force_thr); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::force_thr,&force_thr);  
+#endif
         }
         else if (strcmp("force_thr_ev", word) == 0)
         {
             read_value(ifs, force_thr);
-            Para_Json::set_json_value(Para_Json::force_thr_ev,&force_thr); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::force_thr_ev,&force_thr);  
+#endif
             force_thr = force_thr / 13.6058 * 0.529177;
         }
         else if (strcmp("force_thr_ev2", word) == 0)
         {
             read_value(ifs, force_thr_ev2);
-            Para_Json::set_json_value(Para_Json::force_thr_ev2,&force_thr_ev2); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::force_thr_ev2,&force_thr_ev2);  
+#endif
         }
         else if (strcmp("stress_thr", word) == 0)
         {
             read_value(ifs, stress_thr);
-            Para_Json::set_json_value(Para_Json::stress_thr,&stress_thr); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::stress_thr,&stress_thr);  
+#endif
         }
         else if (strcmp("press1", word) == 0)
         {
             read_value(ifs, press1);
-            Para_Json::set_json_value(Para_Json::press1,&press1); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::press1,&press1);  
+#endif
         }
         else if (strcmp("press2", word) == 0)
         {
             read_value(ifs, press2);
-            Para_Json::set_json_value(Para_Json::press2,&press2); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::press2,&press2);  
+#endif
         }
         else if (strcmp("press3", word) == 0)
         {
             read_value(ifs, press3);
-            Para_Json::set_json_value(Para_Json::press3,&press3); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::press3,&press3);  
+#endif
         }
         else if (strcmp("cal_stress", word) == 0)
         {
             read_bool(ifs, cal_stress);
-            Para_Json::set_json_value(Para_Json::cal_stress,&cal_stress); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cal_stress,&cal_stress);  
+#endif
         }
         else if (strcmp("fixed_axes", word) == 0)
         {
             read_value(ifs, fixed_axes);
-            Para_Json::set_json_value(Para_Json::fixed_axes,&fixed_axes); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::fixed_axes,&fixed_axes);  
+#endif
         }
         else if (strcmp("fixed_ibrav", word) == 0)
         {
             read_bool(ifs, fixed_ibrav);
-            Para_Json::set_json_value(Para_Json::fixed_ibrav,&fixed_ibrav); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::fixed_ibrav,&fixed_ibrav);  
+#endif
         }
         else if (strcmp("fixed_atoms", word) == 0)
         {
             read_bool(ifs, fixed_atoms);
-            Para_Json::set_json_value(Para_Json::fixed_atoms,&fixed_atoms); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::fixed_atoms,&fixed_atoms);  
+#endif
         }
         else if (strcmp("relax_method", word) == 0)
         {
             read_value(ifs, relax_method);
-            Para_Json::set_json_value(Para_Json::relax_method,&relax_method); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_method,&relax_method);  
+#endif
         }
         else if (strcmp("relax_cg_thr", word) == 0) // pengfei add 2013-08-15
         {
             read_value(ifs, relax_cg_thr);
-            Para_Json::set_json_value(Para_Json::relax_cg_thr,&relax_cg_thr); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_cg_thr,&relax_cg_thr);  
+#endif
         }
         else if (strcmp("out_level", word) == 0)
         {
             read_value(ifs, out_level);
             out_md_control = true;
-            Para_Json::set_json_value(Para_Json::out_level,&out_level); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_level,&out_level);  
+#endif
         }
         else if (strcmp("relax_bfgs_w1", word) == 0)
         {
             read_value(ifs, relax_bfgs_w1);
-            Para_Json::set_json_value(Para_Json::relax_bfgs_w1,&relax_bfgs_w1); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_bfgs_w1,&relax_bfgs_w1);  
+#endif
         }
         else if (strcmp("relax_bfgs_w2", word) == 0)
         {
             read_value(ifs, relax_bfgs_w2);
-            Para_Json::set_json_value(Para_Json::relax_bfgs_w2,&relax_bfgs_w2); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_bfgs_w2,&relax_bfgs_w2);  
+#endif
         }
         else if (strcmp("relax_bfgs_rmax", word) == 0)
         {
             read_value(ifs, relax_bfgs_rmax);
-            Para_Json::set_json_value(Para_Json::relax_bfgs_rmax,&relax_bfgs_rmax); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_bfgs_rmax,&relax_bfgs_rmax);  
+#endif
         }
         else if (strcmp("relax_bfgs_rmin", word) == 0)
         {
             read_value(ifs, relax_bfgs_rmin);
-            Para_Json::set_json_value(Para_Json::relax_bfgs_rmin,&relax_bfgs_rmin); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_bfgs_rmin,&relax_bfgs_rmin);  
+#endif
         }
         else if (strcmp("relax_bfgs_init", word) == 0)
         {
             read_value(ifs, relax_bfgs_init);
-            Para_Json::set_json_value(Para_Json::relax_bfgs_init,&relax_bfgs_init); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_bfgs_init,&relax_bfgs_init);  
+#endif
         }
         else if (strcmp("relax_scale_force", word) == 0)
         {
             read_value(ifs, relax_scale_force);
-            Para_Json::set_json_value(Para_Json::relax_scale_force,&relax_scale_force); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_scale_force,&relax_scale_force);  
+#endif
         }
         else if (strcmp("relax_new", word) == 0)
         {
             read_bool(ifs, relax_new);
-            Para_Json::set_json_value(Para_Json::relax_new,&relax_new); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_new,&relax_new);  
+#endif
         }
         else if (strcmp("use_paw", word) == 0)
         {
@@ -1150,7 +1313,9 @@ bool Input::Read(const std::string &fn)
         {
             read_bool(ifs, gamma_only);
             
-            Para_Json::set_json_value(Para_Json::gamma_only,&gamma_only); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::gamma_only,&gamma_only);  
+#endif
         }
         else if (strcmp("fft_mode", word) == 0)
         {
@@ -1159,7 +1324,9 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("ecutwfc", word) == 0)
         {
             read_value(ifs, ecutwfc);
-            Para_Json::set_json_value(Para_Json::ecutwfc,&ecutwfc); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::ecutwfc,&ecutwfc);  
+#endif
         }
         else if (strcmp("ecutrho", word) == 0)
         {
@@ -1168,36 +1335,48 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("nx", word) == 0)
         {
             read_value(ifs, nx);
-            Para_Json::set_json_value(Para_Json::nx,&nx); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nx,&nx);  
+#endif
 
             ncx = nx;
         }
         else if (strcmp("ny", word) == 0)
         {
             read_value(ifs, ny);
-            Para_Json::set_json_value(Para_Json::ny,&ny); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::ny,&ny);  
+#endif
             ncy = ny;
         }
         else if (strcmp("nz", word) == 0)
         {
             read_value(ifs, nz);
-            Para_Json::set_json_value(Para_Json::nz,&nz); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nz,&nz);  
+#endif
             ncz = nz;
         }
         else if (strcmp("bx", word) == 0)
         {
             read_value(ifs, bx);
-            Para_Json::set_json_value(Para_Json::bx,&bx); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bx,&bx);  
+#endif
         }
         else if (strcmp("by", word) == 0)
         {
             read_value(ifs, by);
-            Para_Json::set_json_value(Para_Json::by,&by); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::by,&by);  
+#endif
         }
         else if (strcmp("bz", word) == 0)
         {
             read_value(ifs, bz);
-            Para_Json::set_json_value(Para_Json::bz,&bz); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bz,&bz);  
+#endif
         }
         else if (strcmp("ndx", word) == 0)
         {
@@ -1233,82 +1412,110 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("diago_proc", word) == 0)
         {
             read_value(ifs, diago_proc);
-            Para_Json::set_json_value(Para_Json::diago_proc,&diago_proc); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::diago_proc,&diago_proc);  
+#endif
         }
         else if (strcmp("pw_diag_nmax", word) == 0)
         {
             read_value(ifs, pw_diag_nmax);
-            Para_Json::set_json_value(Para_Json::pw_diag_nmax,&pw_diag_nmax); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::pw_diag_nmax,&pw_diag_nmax);  
+#endif
         }
         else if (strcmp("diago_cg_prec", word) == 0) // mohan add 2012-03-31
         {
             read_value(ifs, diago_cg_prec);
-            //Para_Json::set_json_value(Para_Json::diago_cg_prec,&diago_cg_prec); 
+            
         }
         else if (strcmp("pw_diag_ndim", word) == 0)
         {
             read_value(ifs, pw_diag_ndim);
-            Para_Json::set_json_value(Para_Json::pw_diag_ndim,&pw_diag_ndim); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::pw_diag_ndim,&pw_diag_ndim);  
+#endif
         }
         else if (strcmp("pw_diag_thr", word) == 0)
         {
             read_value(ifs, pw_diag_thr);
-            Para_Json::set_json_value(Para_Json::pw_diag_thr,&pw_diag_thr); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::pw_diag_thr,&pw_diag_thr);  
+#endif
         }
         else if (strcmp("nb2d", word) == 0)
         {
             read_value(ifs, nb2d);
-            Para_Json::set_json_value(Para_Json::nb2d,&nb2d); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nb2d,&nb2d);  
+#endif
         }
         else if (strcmp("nurse", word) == 0)
         {
             read_value(ifs, nurse);
-            //Para_Json::set_json_value(Para_Json::nurse,&nurse); 
+            
         }
         else if (strcmp("colour", word) == 0)
         {
             read_bool(ifs, colour);
-            Para_Json::set_json_value(Para_Json::colour,&colour); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::colour,&colour);  
+#endif
         }
         else if (strcmp("nbspline", word) == 0)
         {
             read_value(ifs, nbspline);
-            Para_Json::set_json_value(Para_Json::nbspline,&nbspline); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nbspline,&nbspline);  
+#endif
         }
         else if (strcmp("t_in_h", word) == 0)
         {
             read_bool(ifs, t_in_h);
-            Para_Json::set_json_value(Para_Json::t_in_h,&t_in_h); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::t_in_h,&t_in_h);  
+#endif
         }
         else if (strcmp("vl_in_h", word) == 0)
         {
             read_bool(ifs, vl_in_h);
-            Para_Json::set_json_value(Para_Json::vl_in_h,&vl_in_h); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vl_in_h,&vl_in_h);  
+#endif
         }
         else if (strcmp("vnl_in_h", word) == 0)
         {
             read_bool(ifs, vnl_in_h);
-            Para_Json::set_json_value(Para_Json::vnl_in_h,&vnl_in_h); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vnl_in_h,&vnl_in_h);  
+#endif
         }
         else if (strcmp("vh_in_h", word) == 0)
         {
             read_bool(ifs, vh_in_h);
-            Para_Json::set_json_value(Para_Json::vh_in_h,&vh_in_h); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vh_in_h,&vh_in_h);  
+#endif
         }
         else if (strcmp("vion_in_h", word) == 0)
         {
             read_bool(ifs, vion_in_h);
-            Para_Json::set_json_value(Para_Json::vion_in_h,&vion_in_h); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vion_in_h,&vion_in_h);  
+#endif
         }
         else if (strcmp("test_force", word) == 0)
         {
             read_bool(ifs, test_force);
-            Para_Json::set_json_value(Para_Json::test_force,&test_force); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::test_force,&test_force);  
+#endif
         }
         else if (strcmp("test_stress", word) == 0)
         {
             read_bool(ifs, test_stress);
-            Para_Json::set_json_value(Para_Json::test_stress,&test_stress); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::test_stress,&test_stress);  
+#endif
         }
         //----------------------------------------------------------
         // iteration
@@ -1316,27 +1523,37 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("scf_thr", word) == 0)
         {
             read_value(ifs, scf_thr);
-            Para_Json::set_json_value(Para_Json::scf_thr,&scf_thr); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::scf_thr,&scf_thr);  
+#endif
         }
         else if (strcmp("scf_thr_type", word) == 0)
         {
             read_value(ifs, scf_thr_type);
-            Para_Json::set_json_value(Para_Json::scf_thr_type,&scf_thr_type); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::scf_thr_type,&scf_thr_type);  
+#endif
         }
         else if (strcmp("scf_nmax", word) == 0)
         {
             read_value(ifs, scf_nmax);
-            Para_Json::set_json_value(Para_Json::scf_nmax,&scf_nmax); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::scf_nmax,&scf_nmax);  
+#endif
         }
         else if (strcmp("relax_nmax", word) == 0)
         {
             read_value(ifs, this->relax_nmax);
-            Para_Json::set_json_value(Para_Json::relax_nmax,&relax_nmax); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::relax_nmax,&relax_nmax);  
+#endif
         }
         else if (strcmp("out_stru", word) == 0)
         {
             read_bool(ifs, out_stru);
-            Para_Json::set_json_value(Para_Json::out_stru,&out_stru); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_stru,&out_stru);  
+#endif
         }
         //----------------------------------------------------------
         // occupation
@@ -1348,12 +1565,16 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("smearing_method", word) == 0)
         {
             read_value(ifs, smearing_method);
-            Para_Json::set_json_value(Para_Json::smearing_method,&smearing_method); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::smearing_method,&smearing_method);  
+#endif
         }
         else if (strcmp("smearing_sigma", word) == 0)
         {
             read_value(ifs, smearing_sigma);
-            Para_Json::set_json_value(Para_Json::smearing_sigma,&smearing_sigma); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::smearing_sigma,&smearing_sigma);  
+#endif
         }
         else if (strcmp("smearing_sigma_temp", word) == 0)
         {
@@ -1367,22 +1588,30 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("mixing_type", word) == 0)
         {
             read_value(ifs, mixing_mode);
-            Para_Json::set_json_value(Para_Json::mixing_type,&mixing_mode); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::mixing_type,&mixing_mode);  
+#endif
         }
         else if (strcmp("mixing_beta", word) == 0)
         {
             read_value(ifs, mixing_beta);
-            Para_Json::set_json_value(Para_Json::mixing_beta,&mixing_beta); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::mixing_beta,&mixing_beta);  
+#endif
         }
         else if (strcmp("mixing_ndim", word) == 0)
         {
             read_value(ifs, mixing_ndim);
-            Para_Json::set_json_value(Para_Json::mixing_ndim,&mixing_ndim); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::mixing_ndim,&mixing_ndim);  
+#endif
         }
         else if (strcmp("mixing_gg0", word) == 0) // mohan add 2014-09-27
         {
             read_value(ifs, mixing_gg0);
-            Para_Json::set_json_value(Para_Json::mixing_gg0,&mixing_gg0); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::mixing_gg0,&mixing_gg0);  
+#endif
         }
         else if (strcmp("mixing_beta_mag", word) == 0)
         {
@@ -1399,12 +1628,16 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("mixing_tau", word) == 0)
         {
             read_bool(ifs, mixing_tau);
-            Para_Json::set_json_value(Para_Json::mixing_tau,&mixing_tau); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::mixing_tau,&mixing_tau);  
+#endif
         }
         else if (strcmp("mixing_dftu", word) == 0)
         {
             read_bool(ifs, mixing_dftu);
-            Para_Json::set_json_value(Para_Json::mixing_dftu,&mixing_dftu); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::mixing_dftu,&mixing_dftu);  
+#endif
         }
         //----------------------------------------------------------
         // charge / potential / wavefunction
@@ -1412,12 +1645,16 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("read_file_dir", word) == 0)
         {
             read_value(ifs, read_file_dir);
-            Para_Json::set_json_value(Para_Json::read_file_dir,&read_file_dir); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::read_file_dir,&read_file_dir);  
+#endif
         }
         else if (strcmp("init_wfc", word) == 0)
         {
             read_value(ifs, init_wfc);
-            Para_Json::set_json_value(Para_Json::init_wfc,&init_wfc); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::init_wfc,&init_wfc);  
+#endif
         }
         else if (strcmp("psi_initializer", word) == 0)
         {
@@ -1426,192 +1663,256 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("mem_saver", word) == 0)
         {
             read_value(ifs, mem_saver);
-            Para_Json::set_json_value(Para_Json::mem_saver,&mem_saver); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::mem_saver,&mem_saver);  
+#endif
         }
         else if (strcmp("printe", word) == 0)
         {
             read_value(ifs, printe);
-            Para_Json::set_json_value(Para_Json::printe,&printe); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::printe,&printe);  
+#endif
         }
         else if (strcmp("init_chg", word) == 0)
         {
             read_value(ifs, init_chg);
-            Para_Json::set_json_value(Para_Json::init_chg,&init_chg); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::init_chg,&init_chg);  
+#endif
         }
         else if (strcmp("chg_extrap", word) == 0) // xiaohui modify 2015-02-01
         {
             read_value(ifs, chg_extrap); // xiaohui modify 2015-02-01
-            Para_Json::set_json_value(Para_Json::chg_extrap,&chg_extrap); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::chg_extrap,&chg_extrap);  
+#endif
         }
         else if (strcmp("out_freq_elec", word) == 0)
         {
             read_value(ifs, out_freq_elec);
-            Para_Json::set_json_value(Para_Json::out_freq_elec,&out_freq_elec); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_freq_elec,&out_freq_elec);  
+#endif
         }
         else if (strcmp("out_freq_ion", word) == 0)
         {
             read_value(ifs, out_freq_ion);
-            Para_Json::set_json_value(Para_Json::out_freq_ion,&out_freq_ion); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_freq_ion,&out_freq_ion);  
+#endif
         }
         else if (strcmp("out_chg", word) == 0)
         {
             read_bool(ifs, out_chg);
-            Para_Json::set_json_value(Para_Json::out_chg,&out_chg); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_chg,&out_chg);  
+#endif
         }
         else if (strcmp("out_dm", word) == 0)
         {
             read_bool(ifs, out_dm);
-            Para_Json::set_json_value(Para_Json::out_dm,&out_dm); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_dm,&out_dm);  
+#endif
         }
         else if (strcmp("out_dm1", word) == 0)
         {
             read_bool(ifs, out_dm1);
-            Para_Json::set_json_value(Para_Json::out_dm1,&out_dm1); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_dm1,&out_dm1);  
+#endif
         }
         else if (strcmp("out_bandgap", word) == 0) // for bandgap printing
         {
             read_bool(ifs, out_bandgap);
-            Para_Json::set_json_value(Para_Json::out_bandgap,&out_bandgap); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_bandgap,&out_bandgap);  
+#endif
         }
         else if (strcmp("deepks_out_labels", word) == 0) // caoyu added 2020-11-24, mohan modified 2021-01-03
         {
             read_bool(ifs, deepks_out_labels);
-            //Para_Json::set_json_value(Para_Json::deepks_out_labels,&deepks_out_labels); 
+            
         }
         else if (strcmp("deepks_scf", word) == 0) // caoyu added 2020-11-24, mohan modified 2021-01-03
         {
             read_bool(ifs, deepks_scf);
-            //Para_Json::set_json_value(Para_Json::deepks_scf,&deepks_scf); 
+            
         }
         else if (strcmp("deepks_bandgap", word) == 0) // caoyu added 2020-11-24, mohan modified 2021-01-03
         {
             read_bool(ifs, deepks_bandgap);
-            //Para_Json::set_json_value(Para_Json::deepks_bandgap,&deepks_bandgap); 
+            
         }
         else if (strcmp("deepks_out_unittest", word) == 0) // mohan added 2021-01-03
         {
             read_bool(ifs, deepks_out_unittest);
-            //Para_Json::set_json_value(Para_Json::deepks_out_unittest,&deepks_out_unittest); 
+            
         }
         else if (strcmp("deepks_model", word) == 0) // caoyu added 2021-06-03
         {
             read_value(ifs, deepks_model);
-            //Para_Json::set_json_value(Para_Json::deepks_model,&deepks_model); 
+            
         }
         else if (strcmp("out_pot", word) == 0)
         {
             read_value(ifs, out_pot);
-            Para_Json::set_json_value(Para_Json::out_pot,&out_pot); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_pot,&out_pot);  
+#endif
         }
         else if (strcmp("out_wfc_pw", word) == 0)
         {
             read_value(ifs, out_wfc_pw);
-            Para_Json::set_json_value(Para_Json::out_wfc_pw,&out_wfc_pw); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_wfc_pw,&out_wfc_pw);  
+#endif
         }
         else if (strcmp("out_wfc_r", word) == 0)
         {
             read_bool(ifs, out_wfc_r);
-            Para_Json::set_json_value(Para_Json::out_wfc_r,&out_wfc_r); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_wfc_r,&out_wfc_r);  
+#endif
         }
         // mohan add 20090909
         else if (strcmp("out_dos", word) == 0)
         {
             read_value(ifs, out_dos);
-            Para_Json::set_json_value(Para_Json::out_dos,&out_dos); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_dos,&out_dos);  
+#endif
         }
         else if (strcmp("out_band", word) == 0)
         {
             read_bool(ifs, out_band);
-            Para_Json::set_json_value(Para_Json::out_band,&out_band); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_band,&out_band);  
+#endif
         }
         else if (strcmp("out_proj_band", word) == 0)
         {
             read_bool(ifs, out_proj_band);
-            Para_Json::set_json_value(Para_Json::out_proj_band,&out_proj_band);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_proj_band,&out_proj_band); 
+#endif
         }
 
         else if (strcmp("out_mat_hs", word) == 0)
         {
             read_bool(ifs, out_mat_hs);
-            Para_Json::set_json_value(Para_Json::out_mat_hs,&out_mat_hs);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_mat_hs,&out_mat_hs); 
+#endif
         }
         // LiuXh add 2019-07-15
         else if (strcmp("out_mat_hs2", word) == 0)
         {
             read_bool(ifs, out_mat_hs2);
-            Para_Json::set_json_value(Para_Json::out_mat_hs2,&out_mat_hs2);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_mat_hs2,&out_mat_hs2); 
+#endif
         }
         else if (strcmp("out_mat_t", word) == 0)
         {
             read_bool(ifs, out_mat_t);
-            Para_Json::set_json_value(Para_Json::out_mat_t,&out_mat_t);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_mat_t,&out_mat_t); 
+#endif
         }
         else if (strcmp("out_mat_dh", word) == 0)
         {
             read_bool(ifs, out_mat_dh);
-            Para_Json::set_json_value(Para_Json::out_mat_dh,&out_mat_dh);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_mat_dh,&out_mat_dh); 
+#endif
         }
         else if (strcmp("out_interval", word) == 0)
         {
             read_value(ifs, out_interval);
-            Para_Json::set_json_value(Para_Json::out_interval,&out_interval); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_interval,&out_interval);  
+#endif
         }
         else if (strcmp("out_app_flag", word) == 0)
         {
             read_bool(ifs, out_app_flag);
-            Para_Json::set_json_value(Para_Json::out_app_flag,&out_app_flag);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_app_flag,&out_app_flag); 
+#endif
         }
         else if (strcmp("out_mat_r", word) == 0)
         {
             read_bool(ifs, out_mat_r);
-            Para_Json::set_json_value(Para_Json::out_mat_r,&out_mat_r);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_mat_r,&out_mat_r); 
+#endif
         }
         else if (strcmp("out_wfc_lcao", word) == 0)
         {
             read_value(ifs, out_wfc_lcao);
-            Para_Json::set_json_value(Para_Json::out_wfc_lcao,&out_wfc_lcao);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_wfc_lcao,&out_wfc_lcao); 
+#endif
         }
         else if (strcmp("out_alllog", word) == 0)
         {
             read_bool(ifs, out_alllog);
-            Para_Json::set_json_value(Para_Json::out_alllog,&out_alllog);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_alllog,&out_alllog); 
+#endif
         }
         else if (strcmp("out_element_info", word) == 0)
         {
             read_bool(ifs, out_element_info);
-            Para_Json::set_json_value(Para_Json::out_element_info,&out_element_info);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::out_element_info,&out_element_info); 
+#endif
         }
         else if (strcmp("dos_emin_ev", word) == 0)
         {
             read_value(ifs, dos_emin_ev);
             dos_setemin = true;
-            Para_Json::set_json_value(Para_Json::dos_emin_ev,&dos_emin_ev); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dos_emin_ev,&dos_emin_ev);  
+#endif
         }
         else if (strcmp("dos_emax_ev", word) == 0)
         {
             read_value(ifs, dos_emax_ev);
-            Para_Json::set_json_value(Para_Json::dos_emax_ev,&dos_emax_ev); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dos_emax_ev,&dos_emax_ev);  
+#endif
             dos_setemax = true;
         }
         else if (strcmp("dos_edelta_ev", word) == 0)
         {
             read_value(ifs, dos_edelta_ev);
-            Para_Json::set_json_value(Para_Json::dos_edelta_ev,&dos_edelta_ev); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dos_edelta_ev,&dos_edelta_ev);  
+#endif
         }
         else if (strcmp("dos_scale", word) == 0)
         {
             read_value(ifs, dos_scale);
-            Para_Json::set_json_value(Para_Json::dos_scale,&dos_scale); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dos_scale,&dos_scale);  
+#endif
         }
         else if (strcmp("dos_sigma", word) == 0)
         {
             read_value(ifs, dos_sigma);
-            Para_Json::set_json_value(Para_Json::dos_sigma,&dos_sigma); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dos_sigma,&dos_sigma);  
+#endif
         }
         else if (strcmp("dos_nche", word) == 0)
         {
             read_value(ifs, dos_nche);
-            Para_Json::set_json_value(Para_Json::dos_nche,&dos_nche); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dos_nche,&dos_nche);  
+#endif
         }
 
         //----------------------------------------------------------
@@ -1621,22 +1922,30 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("lcao_ecut", word) == 0)
         {
             read_value(ifs, lcao_ecut);
-            Para_Json::set_json_value(Para_Json::lcao_ecut,&lcao_ecut); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::lcao_ecut,&lcao_ecut);  
+#endif
         }
         else if (strcmp("lcao_dk", word) == 0)
         {
             read_value(ifs, lcao_dk);
-            Para_Json::set_json_value(Para_Json::lcao_dk,&lcao_dk); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::lcao_dk,&lcao_dk);  
+#endif
         }
         else if (strcmp("lcao_dr", word) == 0)
         {
             read_value(ifs, lcao_dr);
-            Para_Json::set_json_value(Para_Json::lcao_dr,&lcao_dr); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::lcao_dr,&lcao_dr);  
+#endif
         }
         else if (strcmp("lcao_rmax", word) == 0)
         {
             read_value(ifs, lcao_rmax);
-            Para_Json::set_json_value(Para_Json::lcao_rmax,&lcao_rmax); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::lcao_rmax,&lcao_rmax);  
+#endif
         }
         //----------------------------------------------------------
         // Molecule Dynamics
@@ -1645,183 +1954,255 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("md_type", word) == 0)
         {
             read_value(ifs, mdp.md_type);
-            Para_Json::set_json_value(Para_Json::md_type,&mdp.md_type); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_type,&mdp.md_type);  
+#endif
 
         }
         else if (strcmp("md_thermostat", word) == 0)
         {
             read_value(ifs, mdp.md_thermostat);
-            Para_Json::set_json_value(Para_Json::md_thermostat,&mdp.md_thermostat); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_thermostat,&mdp.md_thermostat);  
+#endif
         }
         else if (strcmp("md_nraise", word) == 0)
         {
             read_value(ifs, mdp.md_nraise);
-            Para_Json::set_json_value(Para_Json::md_nraise,&mdp.md_nraise); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_nraise,&mdp.md_nraise);  
+#endif
         }
         else if (strcmp("cal_syns", word) == 0)
         {
             read_value(ifs, cal_syns);
-            Para_Json::set_json_value(Para_Json::cal_syns,&cal_syns);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cal_syns,&cal_syns); 
+#endif
         }
         else if (strcmp("dmax", word) == 0)
         {
             read_value(ifs, dmax);
-            Para_Json::set_json_value(Para_Json::dmax,&dmax); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dmax,&dmax);  
+#endif
         }
         else if (strcmp("md_tolerance", word) == 0)
         {
             read_value(ifs, mdp.md_tolerance);
-            Para_Json::set_json_value(Para_Json::md_tolerance,&mdp.md_tolerance); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_tolerance,&mdp.md_tolerance);  
+#endif
         }
         else if (strcmp("md_nstep", word) == 0)
         {
             read_value(ifs, mdp.md_nstep);
-            Para_Json::set_json_value(Para_Json::md_nstep,&mdp.md_nstep); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_nstep,&mdp.md_nstep);  
+#endif
         }
         else if (strcmp("md_dt", word) == 0)
         {
             read_value(ifs, mdp.md_dt);
-            Para_Json::set_json_value(Para_Json::md_dt,&mdp.md_dt); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_dt,&mdp.md_dt);  
+#endif
         }
         else if (strcmp("md_tchain", word) == 0)
         {
             read_value(ifs, mdp.md_tchain);
-            Para_Json::set_json_value(Para_Json::md_tchain,&mdp.md_tchain); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_tchain,&mdp.md_tchain);  
+#endif
         }
         else if (strcmp("md_tfirst", word) == 0)
         {
             read_value(ifs, mdp.md_tfirst);
-            Para_Json::set_json_value(Para_Json::md_tfirst,&mdp.md_tfirst); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_tfirst,&mdp.md_tfirst);  
+#endif
         }
         else if (strcmp("md_tlast", word) == 0)
         {
             read_value(ifs, mdp.md_tlast);
-            Para_Json::set_json_value(Para_Json::md_tlast,&mdp.md_tlast); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_tlast,&mdp.md_tlast);  
+#endif
         }
         else if (strcmp("md_dumpfreq", word) == 0)
         {
             read_value(ifs, mdp.md_dumpfreq);
-            Para_Json::set_json_value(Para_Json::md_dumpfreq,&mdp.md_dumpfreq); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_dumpfreq,&mdp.md_dumpfreq);  
+#endif
         }
         else if (strcmp("md_restartfreq", word) == 0)
         {
             read_value(ifs, mdp.md_restartfreq);
-            Para_Json::set_json_value(Para_Json::md_restartfreq,&mdp.md_restartfreq); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_restartfreq,&mdp.md_restartfreq);  
+#endif
         }
         else if (strcmp("md_seed", word) == 0)
         {
             read_value(ifs, mdp.md_seed);
-            Para_Json::set_json_value(Para_Json::md_seed,&mdp.md_seed); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_seed,&mdp.md_seed);  
+#endif
         }
         else if (strcmp("md_prec_level", word) == 0)
         {
             read_value(ifs, mdp.md_prec_level);
-            Para_Json::set_json_value(Para_Json::md_prec_level,&mdp.md_prec_level); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_prec_level,&mdp.md_prec_level);  
+#endif
         }
         else if (strcmp("md_restart", word) == 0)
         {
             read_bool(ifs, mdp.md_restart);
-            Para_Json::set_json_value(Para_Json::md_restart,&mdp.md_restart);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_restart,&mdp.md_restart); 
+#endif
         }
         else if (strcmp("md_pmode", word) == 0)
         {
             read_value(ifs, mdp.md_pmode);
-            Para_Json::set_json_value(Para_Json::md_pmode,&mdp.md_pmode); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_pmode,&mdp.md_pmode);  
+#endif
         }
         else if (strcmp("md_pcouple", word) == 0)
         {
             read_value(ifs, mdp.md_pcouple);
-            Para_Json::set_json_value(Para_Json::md_pcouple,&mdp.md_pcouple); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_pcouple,&mdp.md_pcouple);  
+#endif
         }
         else if (strcmp("md_pchain", word) == 0)
         {
             read_value(ifs, mdp.md_pchain);
-            Para_Json::set_json_value(Para_Json::md_pchain,&mdp.md_pchain); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_pchain,&mdp.md_pchain);  
+#endif
         }
         else if (strcmp("md_pfirst", word) == 0)
         {
             read_value(ifs, mdp.md_pfirst);
-            Para_Json::set_json_value(Para_Json::md_pfirst,&mdp.md_pfirst); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_pfirst,&mdp.md_pfirst);  
+#endif
         }
         else if (strcmp("md_plast", word) == 0)
         {
             read_value(ifs, mdp.md_plast);
-            Para_Json::set_json_value(Para_Json::md_plast,&mdp.md_plast); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_plast,&mdp.md_plast);  
+#endif
         }
         else if (strcmp("md_pfreq", word) == 0)
         {
             read_value(ifs, mdp.md_pfreq);
-            Para_Json::set_json_value(Para_Json::md_pfreq,&mdp.md_pfreq); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_pfreq,&mdp.md_pfreq);  
+#endif
         }
         else if (strcmp("lj_rcut", word) == 0)
         {
             read_value(ifs, mdp.lj_rcut);
-            Para_Json::set_json_value(Para_Json::lj_rcut,&mdp.lj_rcut); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::lj_rcut,&mdp.lj_rcut);  
+#endif
         }
         else if (strcmp("lj_epsilon", word) == 0)
         {
             read_value(ifs, mdp.lj_epsilon);
-            Para_Json::set_json_value(Para_Json::lj_epsilon,&mdp.lj_epsilon); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::lj_epsilon,&mdp.lj_epsilon);  
+#endif
         }
         else if (strcmp("lj_sigma", word) == 0)
         {
             read_value(ifs, mdp.lj_sigma);
-            Para_Json::set_json_value(Para_Json::lj_sigma,&mdp.lj_sigma); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::lj_sigma,&mdp.lj_sigma);  
+#endif
         }
         else if (strcmp("msst_direction", word) == 0)
         {
             read_value(ifs, mdp.msst_direction);
-            Para_Json::set_json_value(Para_Json::msst_direction,&mdp.msst_direction); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::msst_direction,&mdp.msst_direction);  
+#endif
         }
         else if (strcmp("msst_vel", word) == 0)
         {
             read_value(ifs, mdp.msst_vel);
-            Para_Json::set_json_value(Para_Json::msst_vel,&mdp.msst_vel); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::msst_vel,&mdp.msst_vel);  
+#endif
         }
         else if (strcmp("msst_vis", word) == 0)
         {
             read_value(ifs, mdp.msst_vis);
-            Para_Json::set_json_value(Para_Json::msst_vis,&mdp.msst_vis); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::msst_vis,&mdp.msst_vis);  
+#endif
         }
         else if (strcmp("msst_tscale", word) == 0)
         {
             read_value(ifs, mdp.msst_tscale);
-            Para_Json::set_json_value(Para_Json::msst_tscale,&mdp.msst_tscale); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::msst_tscale,&mdp.msst_tscale);  
+#endif
         }
         else if (strcmp("msst_qmass", word) == 0)
         {
             read_value(ifs, mdp.msst_qmass);
-            Para_Json::set_json_value(Para_Json::msst_qmass,&mdp.msst_qmass); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::msst_qmass,&mdp.msst_qmass);  
+#endif
         }
         else if (strcmp("md_tfreq", word) == 0)
         {
             read_value(ifs, mdp.md_tfreq);
-            Para_Json::set_json_value(Para_Json::md_tfreq,&mdp.md_tfreq); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_tfreq,&mdp.md_tfreq);  
+#endif
         }
         else if (strcmp("md_damp", word) == 0)
         {
             read_value(ifs, mdp.md_damp);
-            Para_Json::set_json_value(Para_Json::md_damp,&mdp.md_damp); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::md_damp,&mdp.md_damp);  
+#endif
         }
         else if (strcmp("pot_file", word) == 0)
         {
             read_value(ifs, mdp.pot_file);
-            Para_Json::set_json_value(Para_Json::pot_file,&mdp.pot_file); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::pot_file,&mdp.pot_file);  
+#endif
         }
         else if (strcmp("dump_force", word) == 0)
         {
             read_bool(ifs, mdp.dump_force);
-            Para_Json::set_json_value(Para_Json::dump_force,&mdp.dump_force); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dump_force,&mdp.dump_force);  
+#endif
         }
         else if (strcmp("dump_vel", word) == 0)
         {
             read_bool(ifs, mdp.dump_vel);
-            Para_Json::set_json_value(Para_Json::dump_vel,&mdp.dump_vel); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dump_vel,&mdp.dump_vel);  
+#endif
         }
         else if (strcmp("dump_virial", word) == 0)
         {
             read_bool(ifs, mdp.dump_virial);
-            Para_Json::set_json_value(Para_Json::dump_virial,&mdp.dump_virial); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dump_virial,&mdp.dump_virial);  
+#endif
         }
         //----------------------------------------------------------
         // efield and dipole correction
@@ -1830,32 +2211,44 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("efield_flag", word) == 0)
         {
             read_bool(ifs, efield_flag);
-            Para_Json::set_json_value(Para_Json::efield_flag,&efield_flag); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::efield_flag,&efield_flag);  
+#endif
         }
         else if (strcmp("dip_cor_flag", word) == 0)
         {
             read_bool(ifs, dip_cor_flag);
-            Para_Json::set_json_value(Para_Json::dip_cor_flag,&dip_cor_flag); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::dip_cor_flag,&dip_cor_flag);  
+#endif
         }
         else if (strcmp("efield_dir", word) == 0)
         {
             read_value(ifs, efield_dir);
-            Para_Json::set_json_value(Para_Json::efield_dir,&efield_dir); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::efield_dir,&efield_dir);  
+#endif
         }
         else if (strcmp("efield_pos_max", word) == 0)
         {
             read_value(ifs, efield_pos_max);
-            Para_Json::set_json_value(Para_Json::efield_pos_max,&efield_pos_max); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::efield_pos_max,&efield_pos_max);  
+#endif
         }
         else if (strcmp("efield_pos_dec", word) == 0)
         {
             read_value(ifs, efield_pos_dec);
-            Para_Json::set_json_value(Para_Json::efield_pos_dec,&efield_pos_dec); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::efield_pos_dec,&efield_pos_dec);  
+#endif
         }
         else if (strcmp("efield_amp", word) == 0)
         {
             read_value(ifs, efield_amp);
-            Para_Json::set_json_value(Para_Json::efield_amp,&efield_amp); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::efield_amp,&efield_amp);  
+#endif
         }
         //----------------------------------------------------------
         // gatefield (compensating charge)
@@ -1864,37 +2257,49 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("gate_flag", word) == 0)
         {
             read_bool(ifs, gate_flag);
-            Para_Json::set_json_value(Para_Json::gate_flag,&gate_flag); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::gate_flag,&gate_flag);  
+#endif
         }
         else if (strcmp("zgate", word) == 0)
         {
             read_value(ifs, zgate);
-            Para_Json::set_json_value(Para_Json::zgate,&zgate); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::zgate,&zgate);  
+#endif
         }
         else if (strcmp("relax", word) == 0)
         {
             read_bool(ifs, relax);
-            //Para_Json::set_json_value(Para_Json::relax,&relax); 
+            
         }
         else if (strcmp("block", word) == 0)
         {
             read_bool(ifs, block);
-            Para_Json::set_json_value(Para_Json::block,&block); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::block,&block);  
+#endif
         }
         else if (strcmp("block_down", word) == 0)
         {
             read_value(ifs, block_down);
-            Para_Json::set_json_value(Para_Json::block_down,&block_down); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::block_down,&block_down);  
+#endif
         }
         else if (strcmp("block_up", word) == 0)
         {
             read_value(ifs, block_up);
-            Para_Json::set_json_value(Para_Json::block_up,&block_up); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::block_up,&block_up);  
+#endif
         }
         else if (strcmp("block_height", word) == 0)
         {
             read_value(ifs, block_height);
-            Para_Json::set_json_value(Para_Json::block_height,&block_height); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::block_height,&block_height);  
+#endif
         }
         //----------------------------------------------------------
         // tddft
@@ -1903,162 +2308,224 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("td_force_dt", word) == 0)
         {
             read_value(ifs, td_force_dt);
-            //Para_Json::set_json_value(Para_Json::td_force_dt,&td_force_dt); 
+            
         }
         else if (strcmp("td_vext", word) == 0)
         {
             read_value(ifs, td_vext);
-            Para_Json::set_json_value(Para_Json::td_vext,&td_vext); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_vext,&td_vext);  
+#endif
         }
         else if (strcmp("td_vext_dire", word) == 0)
         {
             getline(ifs, td_vext_dire);
-            Para_Json::set_json_value(Para_Json::td_vext_dire,&td_vext_dire); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_vext_dire,&td_vext_dire);  
+#endif
         }
         else if (strcmp("out_dipole", word) == 0)
         {
             read_value(ifs, out_dipole);
-            Para_Json::set_json_value(Para_Json::td_out_dipole,&out_dipole); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_out_dipole,&out_dipole);  
+#endif
         }
         else if (strcmp("out_efield", word) == 0)
         {
             read_value(ifs, out_efield);
-            Para_Json::set_json_value(Para_Json::td_out_efield,&out_efield); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_out_efield,&out_efield);  
+#endif
         }
         else if (strcmp("td_print_eij", word) == 0)
         {
             read_value(ifs, td_print_eij);
-            Para_Json::set_json_value(Para_Json::td_print_eij,&td_print_eij); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_print_eij,&td_print_eij);  
+#endif
         }
         else if (strcmp("td_edm", word) == 0)
         {
             read_value(ifs, td_edm);
-            Para_Json::set_json_value(Para_Json::td_edm,&td_edm); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_edm,&td_edm);  
+#endif
         }
         else if (strcmp("td_propagator", word) == 0)
         {
             read_value(ifs, propagator);
-            Para_Json::set_json_value(Para_Json::td_propagator,&propagator); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_propagator,&propagator);  
+#endif
         }
         else if (strcmp("td_stype", word) == 0)
         {
             read_value(ifs, td_stype);
-            Para_Json::set_json_value(Para_Json::td_stype,&td_stype); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_stype,&td_stype);  
+#endif
         }
         else if (strcmp("td_ttype", word) == 0)
         {
             getline(ifs, td_ttype);
-            Para_Json::set_json_value(Para_Json::td_ttype,&td_ttype); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_ttype,&td_ttype);  
+#endif
         }
         else if (strcmp("td_tstart", word) == 0)
         {
             read_value(ifs, td_tstart);
-            Para_Json::set_json_value(Para_Json::td_tstart,&td_tstart); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_tstart,&td_tstart);  
+#endif
         }
         else if (strcmp("td_tend", word) == 0)
         {
             read_value(ifs, td_tend);
-            Para_Json::set_json_value(Para_Json::td_tend,&td_tend); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_tend,&td_tend);  
+#endif
         }
         else if (strcmp("td_lcut1", word) == 0)
         {
             read_value(ifs, td_lcut1);
-            Para_Json::set_json_value(Para_Json::td_lcut1,&td_lcut1); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_lcut1,&td_lcut1);  
+#endif
         }
         else if (strcmp("td_lcut2", word) == 0)
         {
             read_value(ifs, td_lcut2);
-            Para_Json::set_json_value(Para_Json::td_lcut2,&td_lcut2); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_lcut2,&td_lcut2);  
+#endif
         }
         else if (strcmp("td_gauss_freq", word) == 0)
         {
             getline(ifs, td_gauss_freq);
-            Para_Json::set_json_value(Para_Json::td_gauss_freq,&td_gauss_freq); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_gauss_freq,&td_gauss_freq);  
+#endif
         }
         else if (strcmp("td_gauss_phase", word) == 0)
         {
             getline(ifs, td_gauss_phase);
-            Para_Json::set_json_value(Para_Json::td_gauss_phase,&td_gauss_phase); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_gauss_phase,&td_gauss_phase);  
+#endif
         }
         else if (strcmp("td_gauss_sigma", word) == 0)
         {
             getline(ifs, td_gauss_sigma);
-            Para_Json::set_json_value(Para_Json::td_gauss_sigma,&td_gauss_sigma); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_gauss_sigma,&td_gauss_sigma);  
+#endif
         }
         else if (strcmp("td_gauss_t0", word) == 0)
         {
             getline(ifs, td_gauss_t0);
-            Para_Json::set_json_value(Para_Json::td_gauss_t0,&td_gauss_t0); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_gauss_t0,&td_gauss_t0);  
+#endif
         }
         else if (strcmp("td_gauss_amp", word) == 0)
         {
             getline(ifs, td_gauss_amp);
-            Para_Json::set_json_value(Para_Json::td_gauss_amp,&td_gauss_amp); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_gauss_amp,&td_gauss_amp);  
+#endif
         }
         else if (strcmp("td_trape_freq", word) == 0)
         {
             getline(ifs, td_trape_freq);
-            Para_Json::set_json_value(Para_Json::td_trape_freq,&td_gauss_freq); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trape_freq,&td_gauss_freq);  
+#endif
         }
         else if (strcmp("td_trape_phase", word) == 0)
         {
             getline(ifs, td_trape_phase);
-            Para_Json::set_json_value(Para_Json::td_trape_phase,&td_trape_phase); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trape_phase,&td_trape_phase);  
+#endif
         }
         else if (strcmp("td_trape_t1", word) == 0)
         {
             getline(ifs, td_trape_t1);
-            Para_Json::set_json_value(Para_Json::td_trape_t1,&td_trape_t1); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trape_t1,&td_trape_t1);  
+#endif
         }
         else if (strcmp("td_trape_t2", word) == 0)
         {
             getline(ifs, td_trape_t2);
-            Para_Json::set_json_value(Para_Json::td_trape_t2,&td_trape_t2); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trape_t2,&td_trape_t2);  
+#endif
         }
         else if (strcmp("td_trape_t3", word) == 0)
         {
             getline(ifs, td_trape_t3);
-            Para_Json::set_json_value(Para_Json::td_trape_t3,&td_trape_t3); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trape_t3,&td_trape_t3);  
+#endif
         }
         else if (strcmp("td_trape_amp", word) == 0)
         {
             getline(ifs, td_trape_amp);
-            Para_Json::set_json_value(Para_Json::td_trape_amp,&td_trape_amp); 
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trape_amp,&td_trape_amp);  
+#endif
         }
         else if (strcmp("td_trigo_freq1", word) == 0)
         {
             getline(ifs, td_trigo_freq1);
-            Para_Json::set_json_value(Para_Json::td_trigo_freq1,&td_trigo_freq1);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trigo_freq1,&td_trigo_freq1); 
+#endif
         }
         else if (strcmp("td_trigo_freq2", word) == 0)
         {
             getline(ifs, td_trigo_freq2);
-            Para_Json::set_json_value(Para_Json::td_trigo_freq2,&td_trigo_freq2);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trigo_freq2,&td_trigo_freq2); 
+#endif
         }
         else if (strcmp("td_trigo_phase1", word) == 0)
         {
             getline(ifs, td_trigo_phase1);
-            Para_Json::set_json_value(Para_Json::td_trigo_phase1,&td_trigo_phase1);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trigo_phase1,&td_trigo_phase1); 
+#endif
         }
         else if (strcmp("td_trigo_phase2", word) == 0)
         {
             getline(ifs, td_trigo_phase2);
-            Para_Json::set_json_value(Para_Json::td_trigo_phase2,&td_trigo_phase2);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trigo_phase2,&td_trigo_phase2); 
+#endif
         }
         else if (strcmp("td_trigo_amp", word) == 0)
         {
             getline(ifs, td_trigo_amp);
-            Para_Json::set_json_value(Para_Json::td_trigo_amp,&td_trigo_amp);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_trigo_amp,&td_trigo_amp); 
+#endif
         }
         else if (strcmp("td_heavi_t0", word) == 0)
         {
             getline(ifs, td_heavi_t0);
-            Para_Json::set_json_value(Para_Json::td_heavi_t0,&td_heavi_t0);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_heavi_t0,&td_heavi_t0); 
+#endif
         }
         else if (strcmp("td_heavi_amp", word) == 0)
         {
             getline(ifs, td_heavi_amp);
-            Para_Json::set_json_value(Para_Json::td_heavi_amp,&td_heavi_amp);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::td_heavi_amp,&td_heavi_amp); 
+#endif
         }
         // else if (strcmp("td_hhg_amp1", word) == 0)
         // {
@@ -2099,91 +2566,124 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("vdw_method", word) == 0)
         {
             read_value(ifs, vdw_method);
-            Para_Json::set_json_value(Para_Json::vdw_method,&vdw_method);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_method,&vdw_method); 
+#endif
         }
         else if (strcmp("vdw_s6", word) == 0)
         {
             read_value(ifs, vdw_s6);
-            Para_Json::set_json_value(Para_Json::vdw_s6,&vdw_s6);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_s6,&vdw_s6); 
+#endif
         }
         else if (strcmp("vdw_s8", word) == 0)
         {
             read_value(ifs, vdw_s8);
-            Para_Json::set_json_value(Para_Json::vdw_s8,&vdw_s8);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_s8,&vdw_s8); 
+#endif
         }
         else if (strcmp("vdw_a1", word) == 0)
         {
             read_value(ifs, vdw_a1);
-            Para_Json::set_json_value(Para_Json::vdw_a1,&vdw_a1);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_a1,&vdw_a1); 
+#endif
         }
         else if (strcmp("vdw_a2", word) == 0)
         {
             read_value(ifs, vdw_a2);
-            Para_Json::set_json_value(Para_Json::vdw_a2,&vdw_a2);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_a2,&vdw_a2); 
+#endif
         }
         else if (strcmp("vdw_d", word) == 0)
         {
             read_value(ifs, vdw_d);
-            Para_Json::set_json_value(Para_Json::vdw_d,&vdw_d);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_d,&vdw_d); 
+#endif
         }
         else if (strcmp("vdw_abc", word) == 0)
         {
             read_bool(ifs, vdw_abc);
-            Para_Json::set_json_value(Para_Json::vdw_abc,&vdw_abc);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_abc,&vdw_abc); 
+#endif
         }
         else if (strcmp("vdw_cutoff_radius", word) == 0)
         {
             read_value(ifs, vdw_cutoff_radius);
-            Para_Json::set_json_value(Para_Json::vdw_cutoff_radius,&vdw_cutoff_radius);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cutoff_radius,&vdw_cutoff_radius); 
+#endif
         }
         else if (strcmp("vdw_radius_unit", word) == 0)
         {
             read_value(ifs, vdw_radius_unit);
-            Para_Json::set_json_value(Para_Json::vdw_radius_unit,&vdw_radius_unit);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_radius_unit,&vdw_radius_unit); 
+#endif
         }
         else if (strcmp("vdw_cn_thr", word) == 0)
         {
             read_value(ifs, vdw_cn_thr);
-            Para_Json::set_json_value(Para_Json::vdw_cn_thr,&vdw_cn_thr);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cn_thr,&vdw_cn_thr); 
+#endif
         }
         else if (strcmp("vdw_cn_thr_unit", word) == 0)
         {
             read_value(ifs, vdw_cn_thr_unit);
-            Para_Json::set_json_value(Para_Json::vdw_cn_thr_unit,&vdw_cn_thr_unit);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cn_thr_unit,&vdw_cn_thr_unit); 
+#endif
         }
         else if (strcmp("vdw_c6_file", word) == 0)
         {
             read_value(ifs, vdw_C6_file);
-            Para_Json::set_json_value(Para_Json::vdw_C6_file,&vdw_C6_file);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_C6_file,&vdw_C6_file); 
+#endif
         }
         else if (strcmp("vdw_c6_unit", word) == 0)
         {
             read_value(ifs, vdw_C6_unit);
-            Para_Json::set_json_value(Para_Json::vdw_C6_unit,&vdw_C6_unit);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_C6_unit,&vdw_C6_unit); 
+#endif
         }
         else if (strcmp("vdw_r0_file", word) == 0)
         {
             read_value(ifs, vdw_R0_file);
-            Para_Json::set_json_value(Para_Json::vdw_R0_file,&vdw_R0_file);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_R0_file,&vdw_R0_file); 
+#endif
         }
         else if (strcmp("vdw_r0_unit", word) == 0)
         {
             read_value(ifs, vdw_R0_unit);
-            Para_Json::set_json_value(Para_Json::vdw_R0_unit,&vdw_R0_unit);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_R0_unit,&vdw_R0_unit); 
+#endif
         }
         else if (strcmp("vdw_cutoff_type", word) == 0)
         {
             read_value(ifs, vdw_cutoff_type);
-            Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type); 
+#endif
         }
         else if (strcmp("vdw_cutoff_period", word) == 0)
         {
             ifs >> vdw_cutoff_period.x >> vdw_cutoff_period.y;
             read_value(ifs, vdw_cutoff_period.z);
-
+#ifdef __RAPIDJSON 
             Para_Json::vdw_cutoff_period.PushBack(vdw_cutoff_period.x,Para_Json::doc.GetAllocator());
             Para_Json::vdw_cutoff_period.PushBack(vdw_cutoff_period.y,Para_Json::doc.GetAllocator());
             Para_Json::vdw_cutoff_period.PushBack(vdw_cutoff_period.z,Para_Json::doc.GetAllocator());
+#endif
         }
         //--------------------------------------------------------
         // restart           Peize Lin 2020-04-04
@@ -2191,28 +2691,38 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("restart_save", word) == 0)
         {
             read_bool(ifs, restart_save);
-            Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type); 
+#endif
         }
         else if (strcmp("restart_load", word) == 0)
         {
             read_bool(ifs, restart_load);
-            Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type); 
+#endif
         }
         else if (strcmp("ocp", word) == 0)
         {
             read_bool(ifs, ocp);
-            Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type); 
+#endif
         }
         else if (strcmp("ocp_set", word) == 0)
         {
             getline(ifs, ocp_set);
-            Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type); 
+#endif
             //			ifs.ignore(150, '\n');
         }
         else if (strcmp("out_mul", word) == 0)
         {
             read_bool(ifs, out_mul);
-            Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type); 
+#endif
         } // qifeng add 2019/9/10
         //----------------------------------------------------------
         // exx
@@ -2221,143 +2731,199 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("exx_hybrid_alpha", word) == 0)
         {
             read_value(ifs, exx_hybrid_alpha);
-            Para_Json::set_json_value(Para_Json::exx_hybrid_alpha,&exx_hybrid_alpha);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_hybrid_alpha,&exx_hybrid_alpha); 
+#endif
         }
         else if (strcmp("exx_hse_omega", word) == 0)
         {
             read_value(ifs, exx_hse_omega);
-            Para_Json::set_json_value(Para_Json::exx_hse_omega,&exx_hse_omega);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_hse_omega,&exx_hse_omega); 
+#endif
         }
         else if (strcmp("exx_separate_loop", word) == 0)
         {
             read_bool(ifs, exx_separate_loop);
-            Para_Json::set_json_value(Para_Json::exx_separate_loop,&exx_separate_loop);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_separate_loop,&exx_separate_loop); 
+#endif
         }
         else if (strcmp("exx_hybrid_step", word) == 0)
         {
             read_value(ifs, exx_hybrid_step);
-            Para_Json::set_json_value(Para_Json::exx_hybrid_step,&exx_hybrid_step);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_hybrid_step,&exx_hybrid_step); 
+#endif
         }
         else if (strcmp("exx_mixing_beta", word) == 0)
         {
             read_value(ifs, exx_mixing_beta);
-            Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type); 
+#endif
         }
         else if (strcmp("exx_lambda", word) == 0)
         {
             read_value(ifs, exx_lambda);
-            Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::vdw_cutoff_type,&vdw_cutoff_type); 
+#endif
         }
         else if (strcmp("exx_real_number", word) == 0)
         {
             read_value(ifs, exx_real_number);
             // printf("exx_real_number = %s\n",exx_real_number.c_str());
-            Para_Json::set_json_value(Para_Json::exx_real_number,&exx_real_number);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_real_number,&exx_real_number); 
+#endif
         }
         else if (strcmp("exx_pca_threshold", word) == 0)
         {
             read_value(ifs, exx_pca_threshold);
-            Para_Json::set_json_value(Para_Json::exx_pca_threshold,&exx_pca_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_pca_threshold,&exx_pca_threshold); 
+#endif
         }
         else if (strcmp("exx_c_threshold", word) == 0)
         {
             read_value(ifs, exx_c_threshold);
-            Para_Json::set_json_value(Para_Json::exx_c_threshold,&exx_c_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_c_threshold,&exx_c_threshold); 
+#endif
         }
         else if (strcmp("exx_v_threshold", word) == 0)
         {
             read_value(ifs, exx_v_threshold);
-            Para_Json::set_json_value(Para_Json::exx_v_threshold,&exx_v_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_v_threshold,&exx_v_threshold); 
+#endif
         }
         else if (strcmp("exx_dm_threshold", word) == 0)
         {
             read_value(ifs, exx_dm_threshold);
-            Para_Json::set_json_value(Para_Json::exx_dm_threshold,&exx_dm_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_dm_threshold,&exx_dm_threshold); 
+#endif
         }
         else if (strcmp("exx_schwarz_threshold", word) == 0)
         {
             read_value(ifs, exx_schwarz_threshold);
-            Para_Json::set_json_value(Para_Json::exx_schwarz_threshold,&exx_schwarz_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_schwarz_threshold,&exx_schwarz_threshold); 
+#endif
         }
         else if (strcmp("exx_cauchy_threshold", word) == 0)
         {
             read_value(ifs, exx_cauchy_threshold);
-            Para_Json::set_json_value(Para_Json::exx_cauchy_threshold,&exx_cauchy_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_cauchy_threshold,&exx_cauchy_threshold); 
+#endif
         }
         else if (strcmp("exx_c_grad_threshold", word) == 0)
         {
             read_value(ifs, exx_c_grad_threshold);
-            Para_Json::set_json_value(Para_Json::exx_c_grad_threshold,&exx_c_grad_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_c_grad_threshold,&exx_c_grad_threshold); 
+#endif
         }
         else if (strcmp("exx_v_grad_threshold", word) == 0)
         {
             read_value(ifs, exx_v_grad_threshold);
-            Para_Json::set_json_value(Para_Json::exx_v_grad_threshold,&exx_v_grad_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_v_grad_threshold,&exx_v_grad_threshold); 
+#endif
         }
         else if (strcmp("exx_cauchy_force_threshold", word) == 0)
         {
             read_value(ifs, exx_cauchy_force_threshold);
-            Para_Json::set_json_value(Para_Json::exx_cauchy_force_threshold,&exx_cauchy_force_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_cauchy_force_threshold,&exx_cauchy_force_threshold); 
+#endif
         }
         else if (strcmp("exx_cauchy_stress_threshold", word) == 0)
         {
             read_value(ifs, exx_cauchy_stress_threshold);
-            Para_Json::set_json_value(Para_Json::exx_cauchy_stress_threshold,&exx_cauchy_stress_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_cauchy_stress_threshold,&exx_cauchy_stress_threshold); 
+#endif
         }
         else if (strcmp("exx_ccp_threshold", word) == 0)
         {
             read_value(ifs, exx_ccp_threshold);
-            Para_Json::set_json_value(Para_Json::exx_ccp_threshold,&exx_ccp_threshold);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_ccp_threshold,&exx_ccp_threshold); 
+#endif
         }
         else if (strcmp("exx_ccp_rmesh_times", word) == 0)
         {
             read_value(ifs, exx_ccp_rmesh_times);
-            Para_Json::set_json_value(Para_Json::exx_ccp_rmesh_times,&exx_ccp_rmesh_times);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_ccp_rmesh_times,&exx_ccp_rmesh_times); 
+#endif
         }
         else if (strcmp("exx_distribute_type", word) == 0)
         {
             read_value(ifs, exx_distribute_type);
-            Para_Json::set_json_value(Para_Json::exx_distribute_type,&exx_distribute_type);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_distribute_type,&exx_distribute_type); 
+#endif
         }
         else if (strcmp("exx_opt_orb_lmax", word) == 0)
         {
             read_value(ifs, exx_opt_orb_lmax);
-            Para_Json::set_json_value(Para_Json::exx_opt_orb_lmax,&exx_opt_orb_lmax);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_opt_orb_lmax,&exx_opt_orb_lmax); 
+#endif
         }
         else if (strcmp("exx_opt_orb_ecut", word) == 0)
         {
             read_value(ifs, exx_opt_orb_ecut);
-            Para_Json::set_json_value(Para_Json::exx_opt_orb_ecut,&exx_opt_orb_ecut);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_opt_orb_ecut,&exx_opt_orb_ecut); 
+#endif
         }
         else if (strcmp("exx_opt_orb_tolerence", word) == 0)
         {
             read_value(ifs, exx_opt_orb_tolerence);
-            Para_Json::set_json_value(Para_Json::exx_opt_orb_tolerence,&exx_opt_orb_tolerence);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::exx_opt_orb_tolerence,&exx_opt_orb_tolerence); 
+#endif
         }
         else if (strcmp("noncolin", word) == 0)
         {
             read_bool(ifs, noncolin);
-            Para_Json::set_json_value(Para_Json::noncolin,&noncolin);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::noncolin,&noncolin); 
+#endif
         }
         else if (strcmp("lspinorb", word) == 0)
         {
             read_bool(ifs, lspinorb);
-            Para_Json::set_json_value(Para_Json::lspinorb,&lspinorb);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::lspinorb,&lspinorb); 
+#endif
         }
         else if (strcmp("soc_lambda", word) == 0)
         {
             read_value(ifs, soc_lambda);
-            Para_Json::set_json_value(Para_Json::soc_lambda,&soc_lambda);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::soc_lambda,&soc_lambda); 
+#endif
         }
         else if (strcmp("cell_factor", word) == 0)
         {
             read_value(ifs, cell_factor);
-            Para_Json::set_json_value(Para_Json::cell_factor,&cell_factor);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::cell_factor,&cell_factor); 
+#endif
         }
         else if (strcmp("test_skip_ewald", word) == 0)
         {
             read_bool(ifs, test_skip_ewald);
-            Para_Json::set_json_value(Para_Json::test_skip_ewald,&test_skip_ewald);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::test_skip_ewald,&test_skip_ewald); 
+#endif
         }
         //--------------
         //----------------------------------------------------------------------------------
@@ -2366,7 +2932,7 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("dft_plus_u", word) == 0)
         {
             read_bool(ifs, dft_plus_u);
-            //Para_Json::set_json_value(Para_Json::dft_plus_u,&dft_plus_u);
+            
         }
         else if (strcmp("yukawa_potential", word) == 0)
             ifs.ignore(150, '\n');
@@ -2384,7 +2950,7 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("dft_plus_dmft", word) == 0)
         {
             read_bool(ifs, dft_plus_dmft);
-            //Para_Json::set_json_value(Para_Json::dft_plus_dmft,&dft_plus_dmft);
+            
         }
         //----------------------------------------------------------------------------------
         //         Rong Shi added for RPA
@@ -2392,7 +2958,9 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("rpa", word) == 0)
         {
             read_bool(ifs, rpa);
-            Para_Json::set_json_value(Para_Json::rpa,&rpa);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::rpa,&rpa); 
+#endif
             if (rpa)
                 GlobalV::rpa_setorb = true;
         }
@@ -2402,27 +2970,37 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("imp_sol", word) == 0)
         {
             read_bool(ifs, imp_sol);
-            Para_Json::set_json_value(Para_Json::imp_sol,&imp_sol);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::imp_sol,&imp_sol); 
+#endif
         }
         else if (strcmp("eb_k", word) == 0)
         {
             read_value(ifs, eb_k);
-            Para_Json::set_json_value(Para_Json::eb_k,&eb_k);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::eb_k,&eb_k); 
+#endif
         }
         else if (strcmp("tau", word) == 0)
         {
             read_value(ifs, tau);
-            Para_Json::set_json_value(Para_Json::tau,&tau);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::tau,&tau); 
+#endif
         }
         else if (strcmp("sigma_k", word) == 0)
         {
             read_value(ifs, sigma_k);
-            Para_Json::set_json_value(Para_Json::sigma_k,&sigma_k);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::sigma_k,&sigma_k); 
+#endif
         }
         else if (strcmp("nc_k", word) == 0)
         {
             read_value(ifs, nc_k);
-            Para_Json::set_json_value(Para_Json::nc_k,&nc_k);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::nc_k,&nc_k); 
+#endif
         }
         //----------------------------------------------------------------------------------
         //    OFDFT sunliang added on 2022-05-05
@@ -2430,137 +3008,191 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("of_kinetic", word) == 0)
         {
             read_value(ifs, of_kinetic);
-            Para_Json::set_json_value(Para_Json::of_kinetic,&of_kinetic);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_kinetic,&of_kinetic); 
+#endif
         }
         else if (strcmp("of_method", word) == 0)
         {
             read_value(ifs, of_method);
-            Para_Json::set_json_value(Para_Json::of_method,&of_method);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_method,&of_method); 
+#endif
         }
         else if (strcmp("of_conv", word) == 0)
         {
             read_value(ifs, of_conv);
-            Para_Json::set_json_value(Para_Json::of_conv,&of_conv);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_conv,&of_conv); 
+#endif
         }
         else if (strcmp("of_tole", word) == 0)
         {
             read_value(ifs, of_tole);
-            Para_Json::set_json_value(Para_Json::of_tole,&of_tole);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_tole,&of_tole); 
+#endif
         }
         else if (strcmp("of_tolp", word) == 0)
         {
             read_value(ifs, of_tolp);
-            Para_Json::set_json_value(Para_Json::of_tolp,&of_tolp);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_tolp,&of_tolp); 
+#endif
         }
         else if (strcmp("of_tf_weight", word) == 0)
         {
             read_value(ifs, of_tf_weight);
-            Para_Json::set_json_value(Para_Json::of_tf_weight,&of_tf_weight);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_tf_weight,&of_tf_weight); 
+#endif
         }
         else if (strcmp("of_vw_weight", word) == 0)
         {
             read_value(ifs, of_vw_weight);
-            Para_Json::set_json_value(Para_Json::of_vw_weight,&of_vw_weight);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_vw_weight,&of_vw_weight); 
+#endif
         }
         else if (strcmp("of_wt_alpha", word) == 0)
         {
             read_value(ifs, of_wt_alpha);
-            Para_Json::set_json_value(Para_Json::of_wt_alpha,&of_wt_alpha);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_wt_alpha,&of_wt_alpha); 
+#endif
         }
         else if (strcmp("of_wt_beta", word) == 0)
         {
             read_value(ifs, of_wt_beta);
-            Para_Json::set_json_value(Para_Json::of_wt_beta,&of_wt_beta);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_wt_beta,&of_wt_beta); 
+#endif
         }
         else if (strcmp("of_wt_rho0", word) == 0)
         {
             read_value(ifs, of_wt_rho0);
-            Para_Json::set_json_value(Para_Json::of_wt_rho0,&of_wt_rho0);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_wt_rho0,&of_wt_rho0); 
+#endif
         }
         else if (strcmp("of_hold_rho0", word) == 0)
         {
             read_bool(ifs, of_hold_rho0);
-            Para_Json::set_json_value(Para_Json::of_hold_rho0,&of_hold_rho0);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_hold_rho0,&of_hold_rho0); 
+#endif
         }
         else if (strcmp("of_lkt_a", word) == 0)
         {
             read_value(ifs, of_lkt_a);
-            Para_Json::set_json_value(Para_Json::of_lkt_a,&of_lkt_a);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_lkt_a,&of_lkt_a); 
+#endif
         }
         else if (strcmp("of_full_pw", word) == 0)
         {
             read_bool(ifs, of_full_pw);
-            Para_Json::set_json_value(Para_Json::of_full_pw,&of_full_pw);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_full_pw,&of_full_pw); 
+#endif
         }
         else if (strcmp("of_full_pw_dim", word) == 0)
         {
             read_value(ifs, of_full_pw_dim);
-            Para_Json::set_json_value(Para_Json::of_full_pw_dim,&of_full_pw_dim);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_full_pw_dim,&of_full_pw_dim); 
+#endif
         }
         else if (strcmp("of_read_kernel", word) == 0)
         {
             read_bool(ifs, of_read_kernel);
-            Para_Json::set_json_value(Para_Json::of_read_kernel,&of_read_kernel);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_read_kernel,&of_read_kernel); 
+#endif
         }
         else if (strcmp("of_kernel_file", word) == 0)
         {
             read_value(ifs, of_kernel_file);
-            Para_Json::set_json_value(Para_Json::of_kernel_file,&of_kernel_file);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::of_kernel_file,&of_kernel_file); 
+#endif
         }
         else if (strcmp("bessel_nao_smooth", word) == 0)
         {
             read_value(ifs, bessel_nao_smooth);
-            Para_Json::set_json_value(Para_Json::bessel_nao_smooth,&bessel_nao_smooth);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_nao_smooth,&bessel_nao_smooth); 
+#endif
         }
         else if (strcmp("bessel_nao_sigma", word) == 0)
         {
             read_value(ifs, bessel_nao_sigma);
-            Para_Json::set_json_value(Para_Json::bessel_nao_sigma,&bessel_nao_sigma);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_nao_sigma,&bessel_nao_sigma); 
+#endif
         }
         else if (strcmp("bessel_nao_ecut", word) == 0)
         {
             read_value(ifs, bessel_nao_ecut);
-            Para_Json::set_json_value(Para_Json::bessel_nao_ecut,&bessel_nao_ecut);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_nao_ecut,&bessel_nao_ecut); 
+#endif
         }
         else if (strcmp("bessel_nao_rcut", word) == 0)
         {
             read_value(ifs, bessel_nao_rcut);
-            Para_Json::set_json_value(Para_Json::bessel_nao_rcut,&bessel_nao_rcut);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_nao_rcut,&bessel_nao_rcut); 
+#endif
         }
         else if (strcmp("bessel_nao_tolerence", word) == 0)
         {
             read_value(ifs, bessel_nao_tolerence);
-            Para_Json::set_json_value(Para_Json::bessel_nao_tolerence,&bessel_nao_tolerence);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_nao_tolerence,&bessel_nao_tolerence); 
+#endif
         }
         else if (strcmp("bessel_descriptor_lmax", word) == 0)
         {
             read_value(ifs, bessel_descriptor_lmax);
-            Para_Json::set_json_value(Para_Json::bessel_descriptor_lmax,&bessel_descriptor_lmax);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_descriptor_lmax,&bessel_descriptor_lmax); 
+#endif
         }
         else if (strcmp("bessel_descriptor_smooth", word) == 0)
         {
             read_value(ifs, bessel_descriptor_smooth);
-            Para_Json::set_json_value(Para_Json::bessel_descriptor_smooth,&bessel_descriptor_smooth);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_descriptor_smooth,&bessel_descriptor_smooth); 
+#endif
         }
         else if (strcmp("bessel_descriptor_sigma", word) == 0)
         {
             read_value(ifs, bessel_descriptor_sigma);
-            Para_Json::set_json_value(Para_Json::bessel_descriptor_sigma,&bessel_descriptor_sigma);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_descriptor_sigma,&bessel_descriptor_sigma); 
+#endif
         }
         else if (strcmp("bessel_descriptor_ecut", word) == 0)
         {
             read_value(ifs, bessel_descriptor_ecut);
-            Para_Json::set_json_value(Para_Json::bessel_descriptor_ecut,&bessel_descriptor_ecut);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_descriptor_ecut,&bessel_descriptor_ecut); 
+#endif
         }
         else if (strcmp("bessel_descriptor_rcut", word) == 0)
         {
             read_value(ifs, bessel_descriptor_rcut);
-            Para_Json::set_json_value(Para_Json::bessel_descriptor_rcut,&bessel_descriptor_rcut);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_descriptor_rcut,&bessel_descriptor_rcut); 
+#endif
         }
         else if (strcmp("bessel_descriptor_tolerence", word) == 0)
         {
             read_value(ifs, bessel_descriptor_tolerence);
-            Para_Json::set_json_value(Para_Json::bessel_descriptor_tolerence,&bessel_descriptor_tolerence);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::bessel_descriptor_tolerence,&bessel_descriptor_tolerence); 
+#endif
         }
         //----------------------------------------------------------------------------------
         //    device control denghui added on 2022-11-05
@@ -2568,14 +3200,16 @@ bool Input::Read(const std::string &fn)
         else if (strcmp("device", word) == 0)
         {
             read_value(ifs, device);
-            Para_Json::set_json_value(Para_Json::device,&device);
+#ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::device,&device); 
+#endif
         }
         //----------------------------------------------------------------------------------
         //    precision control denghui added on 2023-01-01
         //----------------------------------------------------------------------------------
         else if (strcmp("precision", word) == 0) {
             read_value(ifs, precision);
-            //Para_Json::set_json_value(Para_Json::precision,&precision);
+            
         }
           //----------------------------------------------------------------------------------
         //    Deltaspin
@@ -2701,19 +3335,25 @@ bool Input::Read(const std::string &fn)
             if (strcmp("yukawa_potential", word) == 0)
             {
                 read_bool(ifs, yukawa_potential);
-                Para_Json::set_json_value(Para_Json::yukawa_potential,&yukawa_potential);
+    #ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::yukawa_potential,&yukawa_potential); 
+#endif
             }
             else if (strcmp("yukawa_lambda", word) == 0)
             {
                 ifs >> yukawa_lambda;
-                Para_Json::set_json_value(Para_Json::yukawa_lambda,&yukawa_lambda);
+    #ifdef __RAPIDJSON 
+		 Para_Json::set_json_value(Para_Json::yukawa_lambda,&yukawa_lambda); 
+#endif
             }
             else if (strcmp("hubbard_u", word) == 0)
             {
                 for (int i = 0; i < ntype; i++)
                 {
                     ifs >> hubbard_u[i];
+#ifdef __RAPIDJSON 
                     Para_Json::hubbard_u.PushBack(hubbard_u[i],Para_Json::doc.GetAllocator());
+#endif
                     hubbard_u[i] /= ModuleBase::Ry_to_eV;
                 }
             }
@@ -2722,7 +3362,9 @@ bool Input::Read(const std::string &fn)
                 for (int i = 0; i < ntype; i++)
                 {
                     ifs >> orbital_corr[i];
+#ifdef __RAPIDJSON 
                     Para_Json::orbital_corr.PushBack(orbital_corr[i],Para_Json::doc.GetAllocator());
+#endif
                 }
             }
             else if (strcmp("omc", word) == 0)
@@ -2797,7 +3439,9 @@ bool Input::Read(const std::string &fn)
                 for (int i = 0; i < ntype; i++)
                 {
                     ifs >> hubbard_u[i];
+#ifdef __RAPIDJSON 
                     Para_Json::hubbard_u.PushBack(hubbard_u[i],Para_Json::doc.GetAllocator());
+#endif
                     hubbard_u[i] /= ModuleBase::Ry_to_eV;
                 }
             }
@@ -2806,7 +3450,9 @@ bool Input::Read(const std::string &fn)
                 for (int i = 0; i < ntype; i++)
                 {
                     ifs >> orbital_corr[i];
+#ifdef __RAPIDJSON 
                     Para_Json::orbital_corr.PushBack(orbital_corr[i],Para_Json::doc.GetAllocator());
+#endif
                 }
             }
             else

--- a/source/module_io/test/CMakeLists.txt
+++ b/source/module_io/test/CMakeLists.txt
@@ -143,11 +143,13 @@ AddTest(
   SOURCES csr_reader_test.cpp ../csr_reader.cpp ../file_reader.cpp ../sparse_matrix.cpp
 )
 
-AddTest(
-  TARGET io_para_json_test
-  LIBS ${math_libs} base device
-  SOURCES para_json_test.cpp ../input.cpp
-)
+if(ENABLE_RAPIDJSON)
+  AddTest(
+    TARGET io_para_json_test
+    LIBS ${math_libs} base device
+    SOURCES para_json_test.cpp ../input.cpp
+  )
+endif()
 
 AddTest(
   TARGET read_rhog_test

--- a/source/module_io/test/para_json_test.cpp
+++ b/source/module_io/test/para_json_test.cpp
@@ -1,9 +1,14 @@
 #include "gtest/gtest.h"
 #include "module_base/global_variable.h"
+#ifdef __RAPIDJSON 
 #include "module_base/para_json.h"
+#endif
 #ifdef __MPI
 #include "mpi.h"
 #endif
+
+
+
 #include <stdlib.h>
 #include "rapidjson/document.h"
 /************************************************
@@ -27,6 +32,7 @@ protected:
 
 #ifdef __MPI
 
+#ifdef __RAPIDJSON 
 // check if a string is a valid JSON string
 bool isValidJSON(const std::string& jsonString) {
     rapidjson::Document document;
@@ -68,7 +74,7 @@ TEST_F(ParaJsonTest,Init)
 	}
 }
 
-
+#endif
 
 int main(int argc, char **argv)
 {
@@ -78,7 +84,10 @@ int main(int argc, char **argv)
 	MPI_Comm_size(MPI_COMM_WORLD,&GlobalV::NPROC);
 	MPI_Comm_rank(MPI_COMM_WORLD,&GlobalV::MY_RANK);
 
-	int result = RUN_ALL_TESTS();
+	int result;
+#ifdef __RAPIDJSON
+	result = RUN_ALL_TESTS();
+#endif
 	MPI_Finalize();
 	return result;
 }

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -60,7 +60,7 @@ Notice: These packages will be downloaded by `wget` from `github.com`, which is 
 
 Instead of github.com, we offer other package station, you can use it by:
 ```shell
-wget https://bohrium-api.dp.tech/ds-dl/abacus-deps-93wi-v2 -O abacus-deps-v1.zip
+wget https://bohrium-api.dp.tech/ds-dl/abacus-deps-93wi-v2 -O abacus-deps.zip
 ```
 `unzip` it ,and you can do offline installation of these packages above after rename. The above station will be updated handly but one should notice that the version will always lower than github repo.
 
@@ -91,6 +91,7 @@ The needed dependencies version default:
 - `LibXC` 6.2.2
 - `ELPA` 2023.05.001
 - `CEREAL` 1.3.2
+- `RapidJSON` 1.1.0
 And Intel-oneAPI need user or server manager to manually install from Intel.
 [Intel-oneAPI](https://www.intel.cn/content/www/cn/zh/developer/tools/oneapi/toolkits.html)
 
@@ -102,12 +103,12 @@ Dependencies below are optional， which is NOT installed by default:
 Users can install them by using `--with-*=install` in toolchain*.sh, which is `no` in default.
 > Notice: LibRI, LibComm and Libnpy is on actively development, you should check-out the package version when using this toolchain. Also, LibRI and LibComm can be installed by github submodule, which is also work for libnpy, which is more recommended.
 
-Notice: for `CEREAL`, `Libnpy`, `LibRI` and `LibComm`, 
+Notice: for `CEREAL`,`RapidJSON`, `Libnpy`, `LibRI` and `LibComm`, 
 you need to download them from github.com, 
 rename it as formatted, and put them in `build` directory at the same time
 e.g.:
 ```shell
-# packages downloaded from github.com
+# packages downloaded from github.com, RapidJSON is not supported now
 mv v1.3.2.tar.gz build/cereal-1.3.2.tar.gz
 ```
 
@@ -175,7 +176,7 @@ cmake -B $BUILD_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX \
         -DCMAKE_CUDA_COMPILER=${path to cuda toolkit}/bin/nvcc \
         ......
 ```
-Notice: You CANNOT use `icpx` compiler for GPU version of ABACUS
+Notice: You CANNOT use `icpx` compiler for GPU version of ABACUS for now
 
 ### shell problem
 If you encounter problem like:
@@ -206,6 +207,8 @@ The default compiler for Intel-oneAPI is `icpx` and `icx`, which will cause prob
 
 The best way is to change `icpx` to `icpc`, `icx` to `icc`. user can manually change it in toolchain*.sh via `--with-intel-classic=yes`
 
+Notice: `icc` and `icpc` from Intel Classic Compiler of Intel-oneAPI is not supported for 2024.0 and newer version.
+
 
 ### LibRI and LibComm problem
 (There is some problem sometimes when compling with LibRI and LibComm, detailed information is needed)
@@ -215,6 +218,9 @@ The best way is to change `icpx` to `icpc`, `icx` to `icc`. user can manually ch
 Sometimes Intel-oneAPI have problem to link `mpirun`, 
 which will always show in 2023.2.0 version of MPI in Intel-oneAPI. 
 Try `source /path/to/setvars.sh` or install another version of IntelMPI may help.
+
+which is fixed in 2024.0.0 version of Intel-oneAPI, 
+And will not occur in Intel-MPI before 2021.10.0 (Intel-oneAPI before 2023.2.0)
 
 More problem and possible solution can be accessed via [#2928](https://github.com/deepmodeling/abacus-develop/issues/2928)
 
@@ -230,9 +236,6 @@ from ABACUS repo, make dependencies package more independent and flexible.
 2. Users can manually change `pkg_install_dir` variable 
 in `scripts/stage*/install*` to change the installation directory 
 of each packages, which may let the installation more fiexible.
-3. Users can manually change `INSTALL` variable in `scripts/common_vars.sh`
-to change the installation directory of all packages, which may let the
-installation more fiexible.
 
 
 ## More

--- a/toolchain/install_abacus_toolchain.sh
+++ b/toolchain/install_abacus_toolchain.sh
@@ -182,10 +182,12 @@ The --with-PKG options follow the rules:
   --with-scalapack        Parallel linear algebra library, needed for parallel
                           calculations.
                           Default = install
+  --with-elpa             Eigenvalue SoLvers for Petaflop-Applications library.
+                          Fast library for large parallel jobs， Especially for ABACUS LCAO
+                          Default = install
   --with-cereal           Enable cereal for ABACUS LCAO
                           Default = install
-  --with-elpa             Eigenvalue SoLvers for Petaflop-Applications library.
-                          Fast library for large parallel jobs.
+  --with-rapidjson        Enable rapidjson for ABACUS to read/write json files
                           Default = install
   --with-libtorch         Enable libtorch the machine learning framework needed for DeePKS
                           Default = no
@@ -230,7 +232,7 @@ EOF
 tool_list="gcc intel cmake"
 mpi_list="mpich openmpi intelmpi"
 math_list="mkl acml openblas"
-lib_list="fftw libxc scalapack elpa cereal libtorch libnpy libri libcomm"
+lib_list="fftw libxc scalapack elpa cereal rapidjson libtorch libnpy libri libcomm"
 package_list="${tool_list} ${mpi_list} ${math_list} ${lib_list}"
 # ------------------------------------------------------------------------
 
@@ -264,7 +266,8 @@ with_acml="__SYSTEM__"
 with_openblas="__INSTALL__"
 with_elpa="__INSTALL__"
 with_cereal="__INSTALL__"
-# with_libtorch="__DONTUSE__"
+with_rapidjson="__INSTALL__"
+# with_libtorch="__DONTUSE__" # default
 # with_libnpy="__DONTUSE__"
 # with_libri="__DONTUSE__"
 # with_libcomm="__DONTUSE__"
@@ -548,6 +551,9 @@ while [ $# -ge 1 ]; do
       ;;
     --with-cereal*)
       with_cereal=$(read_with "${1}")
+      ;;
+    --with-rapidjson*)
+      with_rapidjson=$(read_with "${1}")
       ;;
     --with-libnpy*)
       with_libnpy=$(read_with "${1}")

--- a/toolchain/scripts/common_vars.sh
+++ b/toolchain/scripts/common_vars.sh
@@ -7,8 +7,7 @@
 # directories and files used by the installer
 ROOTDIR=${ROOTDIR:-"$(pwd -P)"}
 SCRIPTDIR=${SCRIPTDIR:-"${ROOTDIR}/scripts"}
-INSTALLDIR=${INSTALLDIR:-"${ROOTDIR}/install"}
-#INSTALLDIR=${INSTALLDIR:-"${HOME}/abacus_deps"} # advanced installation
+INSTALLDIR=${INSTALLDIR:-"${ROOTDIR}/install"} # should not be changed
 BUILDDIR=${BUILDDIR:-"${ROOTDIR}/build"}
 SETUPFILE=${SETUPFILE:-"${INSTALLDIR}/setup"}
 ARCH_FILE_TEMPLATE=${ARCH_FILE_TEMPLATE:-"${SCRIPTDIR}/arch_base.tmpl"}

--- a/toolchain/scripts/stage4/install_rapidjson.sh
+++ b/toolchain/scripts/stage4/install_rapidjson.sh
@@ -1,0 +1,93 @@
+#!/bin/bash -e
+
+# TODO: Review and if possible fix shellcheck errors.
+# shellcheck disable=all
+# RAPIDJSON is not need any complex setting
+# Only problem is the installation from github.com
+
+[ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
+
+rapidjson_ver="1.1.0"
+rapidjson_sha256="bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e"
+source "${SCRIPT_DIR}"/common_vars.sh
+source "${SCRIPT_DIR}"/tool_kit.sh
+source "${SCRIPT_DIR}"/signal_trap.sh
+source "${INSTALLDIR}"/toolchain.conf
+source "${INSTALLDIR}"/toolchain.env
+
+[ -f "${BUILDDIR}/setup_rapidjson" ] && rm "${BUILDDIR}/setup_rapidjson"
+
+RAPIDJSON_CFLAGS=""
+! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
+cd "${BUILDDIR}"
+
+case "$with_rapidjson" in
+  __INSTALL__)
+    echo "==================== Installing RAPIDJSON ===================="
+    dirname="rapidjson-${rapidjson_ver}"
+    pkg_install_dir="${INSTALLDIR}/$dirname"
+    #pkg_install_dir="${HOME}/lib/rapidjson/${rapidjson_ver}"
+    install_lock_file="$pkg_install_dir/install_successful"
+    url="https://github.com/Tencent/rapidjson/archive/refs/tags/v${rapidjson_ver}.tar.gz"
+    filename="rapidjson-${rapidjson_ver}.tar.gz"
+    if verify_checksums "${install_lock_file}"; then
+        echo "$dirname is already installed, skipping it."
+    else
+        if [ -f $filename ]; then
+        echo "$filename is found"
+        else
+        # download from github.com and checksum
+            echo "wget --quiet $url -O $filename"
+            if ! wget --quiet $url -O $filename; then
+            report_error "failed to download $url"
+            recommend_offline_installation $filename $url
+            fi
+        # checksum
+        checksum "$filename" "$rapidjson_sha256"
+        fi
+        echo "Installing from scratch into ${pkg_install_dir}"
+        [ -d $dirname ] && rm -rf $dirname
+        tar -xzf $filename
+        mkdir -p "${pkg_install_dir}"
+        cp -r $dirname/* "${pkg_install_dir}/"
+        write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage4/$(basename ${SCRIPT_NAME})"
+    fi
+        ;;
+    __SYSTEM__)
+        echo "==================== CANNOT Finding RAPIDJSON from system paths NOW ===================="
+        recommend_offline_installation $filename $url
+        # How to do it in rapidjson? -- Zhaoqing in 2023/08/23
+        # check_lib -lxcf03 "libxc"
+        # check_lib -lxc "libxc"
+        # add_include_from_paths LIBXC_CFLAGS "xc.h" $INCLUDE_PATHS
+        # add_lib_from_paths LIBXC_LDFLAGS "libxc.*" $LIB_PATHS
+        ;;
+    __DONTUSE__) ;;
+    
+    *)
+    echo "==================== Linking RAPIDJSON to user paths ===================="
+    check_dir "${pkg_install_dir}"
+    RAPIDJSON_CFLAGS="-I'${pkg_install_dir}'"
+    ;;
+esac
+if [ "$with_rapidjson" != "__DONTUSE__" ]; then
+    if [ "$with_rapidjson" != "__SYSTEM__" ]; then
+    # LibRI deps should find rapidjson include in CPATH
+        cat << EOF > "${BUILDDIR}/setup_rapidjson"
+prepend_path CPATH "$pkg_install_dir/include"
+export CPATH="${pkg_install_dir}/include:"${CPATH}
+EOF
+        cat "${BUILDDIR}/setup_rapidjson" >> $SETUPFILE
+    fi
+    cat << EOF >> "${BUILDDIR}/setup_rapidjson"
+export RAPIDJSON_CFLAGS="${RAPIDJSON_CFLAGS}"
+export RAPIDJSON_ROOT="$pkg_install_dir"
+EOF
+fi
+
+load "${BUILDDIR}/setup_rapidjson"
+write_toolchain_env "${INSTALLDIR}"
+
+cd "${ROOTDIR}"
+report_timing "rapidjson"

--- a/toolchain/scripts/stage4/install_stage4.sh
+++ b/toolchain/scripts/stage4/install_stage4.sh
@@ -4,6 +4,7 @@
 # shellcheck disable=all
 
 ./scripts/stage4/install_cereal.sh
+./scripts/stage4/install_rapidjson.sh
 ./scripts/stage4/install_libtorch.sh
 ./scripts/stage4/install_libnpy.sh
 ./scripts/stage4/install_libri.sh

--- a/toolchain/scripts/tool_kit.sh
+++ b/toolchain/scripts/tool_kit.sh
@@ -54,9 +54,12 @@ By download $__filename from $__url,
 Rename it as $__filename and put it into ${BUILDDIR},
 And re-run toolchain installation script.
 
-Instead of github.com. you can manually install requirements packages via:
-1. Download from www.cp2k.org/static/downloads
-2. wget https://bohrium-api.dp.tech/ds-dl/abacus-deps-93wi-v1 -O abacus-deps-v1.zip
+You can manually install requirements packages via:
+1. Download from www.cp2k.org/static/downloads (for OpenBLAS, OpenMPI and Others)
+2. Download from github.com (for CEREAL, RapidJSON, libnpy, LibRI and others stage4 packages)
+3. Use git submodule update --init --recursive (for LibRI)
+4. wget https://bohrium-api.dp.tech/ds-dl/abacus-deps-93wi-v2 -O abacus-deps.zip
+5. for Intel-oneAPI, please contact your server manager our visit Intel official website
 EOF
 }
 

--- a/toolchain/toolchain_gnu.sh
+++ b/toolchain/toolchain_gnu.sh
@@ -18,6 +18,7 @@
 --with-fftw=install \
 --with-elpa=install \
 --with-cereal=install \
+--with-rapidjson=install \
 --with-libtorch=no \
 --with-libnpy=no \
 --with-libri=no \

--- a/toolchain/toolchain_intel-mpich.sh
+++ b/toolchain/toolchain_intel-mpich.sh
@@ -21,6 +21,7 @@
 --with-fftw=no \
 --with-elpa=install \
 --with-cereal=install \
+--with-rapidjson=install \
 --with-libtorch=no \
 --with-libnpy=no \
 --with-libri=no \

--- a/toolchain/toolchain_intel.sh
+++ b/toolchain/toolchain_intel.sh
@@ -22,6 +22,7 @@
 --with-fftw=no \
 --with-elpa=install \
 --with-cereal=install \
+--with-rapidjson=install \
 --with-libtorch=no \
 --with-libnpy=no \
 --with-libri=no \


### PR DESCRIPTION
abacus.json is used to storage some key values of abacus output. 
This commit is to add a complier option to control if open this function.
The content of abacus.json is not ready now, we will complete it in recently future.

### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
