### PR TITLE
fix:add OpenMP parallelization to BPCG CPU kernel band loops (assisted with Deepseek V4)

### DIFF
--- a/source/source_hsolver/kernels/bpcg_kernel_op.cpp
+++ b/source/source_hsolver/kernels/bpcg_kernel_op.cpp
@@ -18,12 +18,18 @@ struct line_minimize_with_block_op<T, base_device::DEVICE_CPU>
                     const int& n_basis_max,
                     const int& n_band)
     {
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
         for (int band_idx = 0; band_idx < n_band; band_idx++)
         {
             Real epsilo_0 = 0.0, epsilo_1 = 0.0, epsilo_2 = 0.0;
             Real theta = 0.0, cos_theta = 0.0, sin_theta = 0.0;
             auto A = reinterpret_cast<const Real*>(grad_out + band_idx * n_basis_max);
             Real norm = BlasConnector::dot(2 * n_basis, A, 1, A, 1);
+#ifdef _OPENMP
+#pragma omp critical(reduce_norm)
+#endif
             Parallel_Reduce::reduce_pool(norm);
             norm = 1.0 / sqrt(norm);
             for (int basis_idx = 0; basis_idx < n_basis; basis_idx++)
@@ -35,8 +41,17 @@ struct line_minimize_with_block_op<T, base_device::DEVICE_CPU>
                 epsilo_1 += std::real(grad_out[item] * std::conj(hpsi_out[item]));
                 epsilo_2 += std::real(grad_out[item] * std::conj(hgrad_out[item]));
             }
+#ifdef _OPENMP
+#pragma omp critical(reduce_epsilo)
+#endif
             Parallel_Reduce::reduce_pool(epsilo_0);
+#ifdef _OPENMP
+#pragma omp critical(reduce_epsilo)
+#endif
             Parallel_Reduce::reduce_pool(epsilo_1);
+#ifdef _OPENMP
+#pragma omp critical(reduce_epsilo)
+#endif
             Parallel_Reduce::reduce_pool(epsilo_2);
             theta = 0.5 * std::abs(std::atan(2 * epsilo_1 / (epsilo_0 - epsilo_2)));
             cos_theta = std::cos(theta);
@@ -66,6 +81,9 @@ struct calc_grad_with_block_op<T, base_device::DEVICE_CPU>
                     const int& n_basis_max,
                     const int& n_band)
     {
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
         for (int band_idx = 0; band_idx < n_band; band_idx++)
         {
             Real err = 0.0;
@@ -75,6 +93,9 @@ struct calc_grad_with_block_op<T, base_device::DEVICE_CPU>
             T grad_1 = {0.0, 0.0};
             auto A = reinterpret_cast<const Real*>(psi_out + band_idx * n_basis_max);
             Real norm = BlasConnector::dot(2 * n_basis, A, 1, A, 1);
+#ifdef _OPENMP
+#pragma omp critical(reduce_norm)
+#endif
             Parallel_Reduce::reduce_pool(norm);
             norm = 1.0 / sqrt(norm);
             for (int basis_idx = 0; basis_idx < n_basis; basis_idx++)
@@ -84,6 +105,9 @@ struct calc_grad_with_block_op<T, base_device::DEVICE_CPU>
                 hpsi_out[item] *= norm;
                 epsilo += std::real(hpsi_out[item] * std::conj(psi_out[item]));
             }
+#ifdef _OPENMP
+#pragma omp critical(reduce_epsilo)
+#endif
             Parallel_Reduce::reduce_pool(epsilo);
             for (int basis_idx = 0; basis_idx < n_basis; basis_idx++)
             {
@@ -93,7 +117,13 @@ struct calc_grad_with_block_op<T, base_device::DEVICE_CPU>
                 err += grad_2;
                 beta += grad_2 / prec_in[basis_idx]; /// Mark here as we should div the prec?
             }
+#ifdef _OPENMP
+#pragma omp critical(reduce_err)
+#endif
             Parallel_Reduce::reduce_pool(err);
+#ifdef _OPENMP
+#pragma omp critical(reduce_beta)
+#endif
             Parallel_Reduce::reduce_pool(beta);
             for (int basis_idx = 0; basis_idx < n_basis; basis_idx++)
             {


### PR DESCRIPTION
 ### Linked Issue 
Add OpenMP parallelization to BPCG CPU kernels for improved performance
 
 ### Unit Tests and/or Case Tests for my changes 
 - Existing unit tests in `source/source_hsolver/kernels/test/` cover the BPCG functionality
 - Verified numerical correctness by running existing test cases with both single-threaded and multi-threaded configurations
 - Performance benchmarking shows significant speedup with multi-threaded execution
 
 ### What's changed? 
 - Added OpenMP parallelization directives (`#pragma omp parallel for`) to the outer band loops in `line_minimize_with_block_op<CPU>` and `calc_grad_with_block_op<CPU>` in `bpcg_kernel_op.cpp`
 - Added `#pragma omp critical` sections to protect MPI reduction calls (`Parallel_Reduce::reduce_pool`) ensuring thread safety
 - All OpenMP directives are wrapped with `#ifdef _OPENMP` for conditional compilation, maintaining backward compatibility with non-OpenMP builds
 - The parallelization targets band-level data parallelism where each band's computation is independent
 - Expected performance improvement scales with the number of bands and available CPU cores
 
 ### Any changes of core modules? (ignore if not applicable) 
 - Modified `HSolver` module: Enhanced `bpcg_kernel_op.cpp` with OpenMP parallelization for CPU kernels
 - The changes affect `line_minimize_with_block_op` and `calc_grad_with_block_op` structures which are critical for BPCG diagonalization performance
 - No changes to class interfaces or virtual functions - modifications are purely implementation-level optimizations
 - GPU code paths remain unchanged; this optimization only affects CPU execution
