### PR TITLE
docs: fix typo calculte -> calculate

### DIFF
--- a/docs/quick_start/hands_on.md
+++ b/docs/quick_start/hands_on.md
@@ -44,7 +44,7 @@ O                       #Name of element
 0.0  0.5  0.0  0 0 0    #x,y,z, move_x, move_y, move_z
 ```
 
-Next, the `INPUT` file is required, which sets all key parameters to direct ABACUS how to calculte and what to output:
+Next, the `INPUT` file is required, which sets all key parameters to direct ABACUS how to calculate and what to output:
 ```
 INPUT_PARAMETERS
 suffix                  MgO


### PR DESCRIPTION
Corrects the misspelling `calculte` -> `calculate` in `docs/quick_start/hands_on.md`.

Documentation only, no behaviour change.